### PR TITLE
feat: add global notifier

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -3,6 +3,7 @@ import { ThemeProvider, CssBaseline } from "@mui/material";
 import { theme } from "./theme";
 import { MainLayout } from "../layouts/MainLayout";
 import ScreenplayPage from "../pages/ScreenplayPage";
+import { NotifySnackbar } from "../states/useNotify";
 
 export default function App() {
   return (
@@ -11,6 +12,7 @@ export default function App() {
       <MainLayout>
         <ScreenplayPage />
       </MainLayout>
+      <NotifySnackbar />
     </ThemeProvider>
   );
 }

--- a/src/states/S1SynopsisView.tsx
+++ b/src/states/S1SynopsisView.tsx
@@ -1,6 +1,17 @@
 // src/states/S1SynopsisView.tsx
 import { useState } from "react";
-import { Box, Stack, TextField, Button, Dialog, DialogTitle, DialogContent, DialogActions, Typography } from "@mui/material";
+import {
+  Box,
+  Stack,
+  TextField,
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Typography,
+} from "@mui/material";
+import { useNotify } from "./useNotify";
 import type { useAppViewModel } from "../vm/useAppViewModel";
 import type { useStateMachine } from "../vm/useStateMachine";
 import { proposeSynopsis } from "../services/aiJobsService";
@@ -12,6 +23,7 @@ export default function S1SynopsisView({ vm, sm }: { vm: VM; sm: SM }) {
   const [idea, setIdea] = useState("");
   const [proposal, setProposal] = useState<string | null>(null);
   const [previewOpen, setPreviewOpen] = useState(false);
+  const notify = useNotify();
 
   const sp = vm.screenplay;
   if (!sp) return <Typography variant="body2">Loading screenplay…</Typography>;
@@ -21,7 +33,7 @@ export default function S1SynopsisView({ vm, sm }: { vm: VM; sm: SM }) {
       idea,
       genre: sp.genre,
       tone: sp.tone,
-      currentSynopsis: sp.synopsis
+      currentSynopsis: sp.synopsis,
     });
     setProposal(res.proposal);
     setPreviewOpen(true);
@@ -39,13 +51,16 @@ export default function S1SynopsisView({ vm, sm }: { vm: VM; sm: SM }) {
       synopsis: sp.synopsis,
       logline: sp.logline,
       genre: sp.genre,
-      tone: sp.tone
+      tone: sp.tone,
     });
   };
 
   const onApprove = async () => {
     const ok = await sm.requestTransition("S2_TREATMENT");
-    if (!ok) alert("Guard fails: ensure the synopsis has enough content (>= ~40 chars in mock).");
+    if (!ok)
+      notify(
+        "Guard fails: ensure the synopsis has enough content (>= ~40 chars in mock).",
+      );
   };
 
   return (
@@ -54,26 +69,38 @@ export default function S1SynopsisView({ vm, sm }: { vm: VM; sm: SM }) {
         <TextField
           label="Working title"
           value={sp.title}
-          onChange={(e) => { vm.setScreenplay({ ...sp, title: e.target.value }); vm.markDirty("S1_SYNOPSIS", true); }}
+          onChange={(e) => {
+            vm.setScreenplay({ ...sp, title: e.target.value });
+            vm.markDirty("S1_SYNOPSIS", true);
+          }}
         />
         <Stack direction="row" spacing={2}>
           <TextField
             label="Genre"
             value={sp.genre ?? ""}
-            onChange={(e) => { vm.setScreenplay({ ...sp, genre: e.target.value }); vm.markDirty("S1_SYNOPSIS", true); }}
+            onChange={(e) => {
+              vm.setScreenplay({ ...sp, genre: e.target.value });
+              vm.markDirty("S1_SYNOPSIS", true);
+            }}
             sx={{ flex: 1 }}
           />
           <TextField
             label="Tone"
             value={sp.tone ?? ""}
-            onChange={(e) => { vm.setScreenplay({ ...sp, tone: e.target.value }); vm.markDirty("S1_SYNOPSIS", true); }}
+            onChange={(e) => {
+              vm.setScreenplay({ ...sp, tone: e.target.value });
+              vm.markDirty("S1_SYNOPSIS", true);
+            }}
             sx={{ flex: 1 }}
           />
         </Stack>
         <TextField
           label="Logline"
           value={sp.logline ?? ""}
-          onChange={(e) => { vm.setScreenplay({ ...sp, logline: e.target.value }); vm.markDirty("S1_SYNOPSIS", true); }}
+          onChange={(e) => {
+            vm.setScreenplay({ ...sp, logline: e.target.value });
+            vm.markDirty("S1_SYNOPSIS", true);
+          }}
           helperText="One-sentence promise of the story"
         />
         <TextField
@@ -85,27 +112,46 @@ export default function S1SynopsisView({ vm, sm }: { vm: VM; sm: SM }) {
         <TextField
           label="Synopsis"
           value={sp.synopsis ?? ""}
-          onChange={(e) => { vm.setScreenplay({ ...sp, synopsis: e.target.value }); vm.markDirty("S1_SYNOPSIS", true); }}
-          multiline minRows={6}
+          onChange={(e) => {
+            vm.setScreenplay({ ...sp, synopsis: e.target.value });
+            vm.markDirty("S1_SYNOPSIS", true);
+          }}
+          multiline
+          minRows={6}
         />
 
         <Stack direction="row" spacing={1}>
-          <Button variant="outlined" onClick={onPropose}>Propose with AI</Button>
-          <Button variant="contained" onClick={onSave} disabled={!vm.dirtyByState["S1_SYNOPSIS"]}>
+          <Button variant="outlined" onClick={onPropose}>
+            Propose with AI
+          </Button>
+          <Button
+            variant="contained"
+            onClick={onSave}
+            disabled={!vm.dirtyByState["S1_SYNOPSIS"]}
+          >
             Save
           </Button>
-          <Button color="secondary" onClick={onApprove}>Approve & Continue (→ S2)</Button>
+          <Button color="secondary" onClick={onApprove}>
+            Approve & Continue (→ S2)
+          </Button>
         </Stack>
       </Stack>
 
-      <Dialog open={previewOpen} onClose={() => setPreviewOpen(false)} maxWidth="md" fullWidth>
+      <Dialog
+        open={previewOpen}
+        onClose={() => setPreviewOpen(false)}
+        maxWidth="md"
+        fullWidth
+      >
         <DialogTitle>AI Proposal — Synopsis</DialogTitle>
         <DialogContent dividers>
           <Typography whiteSpace="pre-wrap">{proposal}</Typography>
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setPreviewOpen(false)}>Close</Button>
-          <Button variant="contained" onClick={applyProposal}>Apply to Synopsis</Button>
+          <Button variant="contained" onClick={applyProposal}>
+            Apply to Synopsis
+          </Button>
         </DialogActions>
       </Dialog>
     </Box>

--- a/src/states/S3TurningPointsView.tsx
+++ b/src/states/S3TurningPointsView.tsx
@@ -1,12 +1,31 @@
 // src/states/S3TurningPointsView.tsx
 import { useMemo, useState } from "react";
 import {
-  Box, Stack, TextField, Button, Typography, Select, MenuItem, Chip, Paper, Grid, Dialog, DialogTitle, DialogContent, DialogActions
+  Box,
+  Stack,
+  TextField,
+  Button,
+  Typography,
+  Select,
+  MenuItem,
+  Chip,
+  Paper,
+  Grid,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
 } from "@mui/material";
+import { useNotify } from "./useNotify";
 import type { useAppViewModel } from "../vm/useAppViewModel";
 import type { useStateMachine } from "../vm/useStateMachine";
 import { useAiJobs } from "../vm/useAiJobs";
-import { TP_ORDER, TP_LABEL, type TurningPoint, type TurningPointType } from "../models/turningPoints";
+import {
+  TP_ORDER,
+  TP_LABEL,
+  type TurningPoint,
+  type TurningPointType,
+} from "../models/turningPoints";
 
 type VM = ReturnType<typeof useAppViewModel>;
 type SM = ReturnType<typeof useStateMachine>;
@@ -15,33 +34,43 @@ const EMPTY_ROWS: TurningPoint[] = TP_ORDER.map((t, i) => ({
   id: i + 1,
   type: t,
   summary: "",
-  order: i + 1
+  order: i + 1,
 }));
 
 export default function S3TurningPointsView({ vm, sm }: { vm: VM; sm: SM }) {
   const ai = useAiJobs();
+  const notify = useNotify();
   const sp = vm.screenplay;
   if (!sp) return <Typography variant="body2">Loading screenplay…</Typography>;
 
-  const rows = (sp.turning_points && sp.turning_points.length ? sp.turning_points : EMPTY_ROWS);
+  const rows =
+    sp.turning_points && sp.turning_points.length
+      ? sp.turning_points
+      : EMPTY_ROWS;
 
   const setRow = (idx: number, patch: Partial<TurningPoint>) => {
-    const clone = rows.map(r => ({ ...r }));
+    const clone = rows.map((r) => ({ ...r }));
     clone[idx] = { ...clone[idx], ...patch };
     vm.setScreenplay({ ...sp, turning_points: clone });
     vm.markDirty("S3_TURNING_POINTS" as any, true);
   };
 
-  const counts = useMemo(() => ({
-    filled: rows.filter(r => (r.summary?.trim().length ?? 0) > 0).length,
-    uniqueTypes: new Set(rows.map(r => r.type)).size,
-    uniqueOrders: new Set(rows.map(r => r.order)).size
-  }), [rows]);
+  const counts = useMemo(
+    () => ({
+      filled: rows.filter((r) => (r.summary?.trim().length ?? 0) > 0).length,
+      uniqueTypes: new Set(rows.map((r) => r.type)).size,
+      uniqueOrders: new Set(rows.map((r) => r.order)).size,
+    }),
+    [rows],
+  );
 
   const [aiPreview, setAiPreview] = useState<TurningPoint[] | null>(null);
 
   const proposeAll = async () => {
-    const res = await ai.proposeTurningPoints(sp.id, { treatment: sp.treatment, constraints: [sp.genre ?? "", sp.tone ?? ""].filter(Boolean) });
+    const res = await ai.proposeTurningPoints(sp.id, {
+      treatment: sp.treatment,
+      constraints: [sp.genre ?? "", sp.tone ?? ""].filter(Boolean),
+    });
     const preview = res.items.map((it, i) => ({ id: i + 1, ...it }));
     setAiPreview(preview);
   };
@@ -60,7 +89,9 @@ export default function S3TurningPointsView({ vm, sm }: { vm: VM; sm: SM }) {
   const approve = async () => {
     const ok = await sm.requestTransition("S4_CHARACTERS");
     if (!ok) {
-      alert("Guard fails: need 5 unique types, unique orders 1..5 and non-empty summaries (≥15 chars).");
+      notify(
+        "Guard fails: need 5 unique types, unique orders 1..5 and non-empty summaries (≥15 chars).",
+      );
     }
   };
 
@@ -68,40 +99,73 @@ export default function S3TurningPointsView({ vm, sm }: { vm: VM; sm: SM }) {
     <Box>
       <Stack spacing={2}>
         <Typography variant="body2" color="text.secondary">
-          Define the five structural turning points. You can ask AI to propose them from the Treatment.
+          Define the five structural turning points. You can ask AI to propose
+          them from the Treatment.
         </Typography>
 
         <Paper variant="outlined">
           <Grid container p={1} sx={{ bgcolor: "grey.50" }}>
-            <Grid item xs={12} md={3}><Typography variant="caption">Type</Typography></Grid>
-            <Grid item xs={12} md={7}><Typography variant="caption">Summary</Typography></Grid>
-            <Grid item xs={12} md={2}><Typography variant="caption">Order</Typography></Grid>
+            <Grid item xs={12} md={3}>
+              <Typography variant="caption">Type</Typography>
+            </Grid>
+            <Grid item xs={12} md={7}>
+              <Typography variant="caption">Summary</Typography>
+            </Grid>
+            <Grid item xs={12} md={2}>
+              <Typography variant="caption">Order</Typography>
+            </Grid>
           </Grid>
 
           {rows.map((row, idx) => (
-            <Grid key={row.id} container alignItems="center" p={1} spacing={1} sx={{ borderTop: "1px solid", borderColor: "divider" }}>
+            <Grid
+              key={row.id}
+              container
+              alignItems="center"
+              p={1}
+              spacing={1}
+              sx={{ borderTop: "1px solid", borderColor: "divider" }}
+            >
               <Grid item xs={12} md={3}>
                 <Select
-                  fullWidth size="small" value={row.type}
-                  onChange={(e) => setRow(idx, { type: e.target.value as TurningPointType })}
+                  fullWidth
+                  size="small"
+                  value={row.type}
+                  onChange={(e) =>
+                    setRow(idx, { type: e.target.value as TurningPointType })
+                  }
                 >
-                  {TP_ORDER.map(t => <MenuItem key={t} value={t}>{TP_LABEL[t]}</MenuItem>)}
+                  {TP_ORDER.map((t) => (
+                    <MenuItem key={t} value={t}>
+                      {TP_LABEL[t]}
+                    </MenuItem>
+                  ))}
                 </Select>
               </Grid>
               <Grid item xs={12} md={7}>
                 <TextField
                   value={row.summary}
                   onChange={(e) => setRow(idx, { summary: e.target.value })}
-                  size="small" fullWidth multiline minRows={2}
+                  size="small"
+                  fullWidth
+                  multiline
+                  minRows={2}
                   placeholder="What happens here and how it changes trajectory?"
                 />
               </Grid>
               <Grid item xs={12} md={2}>
                 <Select
-                  fullWidth size="small" value={row.order}
-                  onChange={(e) => setRow(idx, { order: Number(e.target.value) })}
+                  fullWidth
+                  size="small"
+                  value={row.order}
+                  onChange={(e) =>
+                    setRow(idx, { order: Number(e.target.value) })
+                  }
                 >
-                  {[1,2,3,4,5].map(n => <MenuItem key={n} value={n}>{n}</MenuItem>)}
+                  {[1, 2, 3, 4, 5].map((n) => (
+                    <MenuItem key={n} value={n}>
+                      {n}
+                    </MenuItem>
+                  ))}
                 </Select>
               </Grid>
             </Grid>
@@ -109,28 +173,52 @@ export default function S3TurningPointsView({ vm, sm }: { vm: VM; sm: SM }) {
         </Paper>
 
         <Stack direction="row" spacing={1} alignItems="center">
-          <Button variant="outlined" onClick={proposeAll} disabled={ai.loading}>Propose from Treatment</Button>
-          <Button variant="contained" onClick={save} disabled={!vm.dirtyByState["S3_TURNING_POINTS" as any]}>Save</Button>
-          <Button color="secondary" onClick={approve}>Approve & Continue (→ S4)</Button>
+          <Button variant="outlined" onClick={proposeAll} disabled={ai.loading}>
+            Propose from Treatment
+          </Button>
+          <Button
+            variant="contained"
+            onClick={save}
+            disabled={!vm.dirtyByState["S3_TURNING_POINTS" as any]}
+          >
+            Save
+          </Button>
+          <Button color="secondary" onClick={approve}>
+            Approve & Continue (→ S4)
+          </Button>
           <Chip size="small" label={`Filled: ${counts.filled}/5`} />
           <Chip size="small" label={`Unique types: ${counts.uniqueTypes}/5`} />
-          <Chip size="small" label={`Unique orders: ${counts.uniqueOrders}/5`} />
+          <Chip
+            size="small"
+            label={`Unique orders: ${counts.uniqueOrders}/5`}
+          />
         </Stack>
       </Stack>
 
-      <Dialog open={!!aiPreview} onClose={() => setAiPreview(null)} maxWidth="md" fullWidth>
+      <Dialog
+        open={!!aiPreview}
+        onClose={() => setAiPreview(null)}
+        maxWidth="md"
+        fullWidth
+      >
         <DialogTitle>AI Proposal — Turning Points</DialogTitle>
         <DialogContent dividers>
-          {aiPreview?.map(tp => (
+          {aiPreview?.map((tp) => (
             <Box key={tp.id} mb={2}>
-              <Typography variant="subtitle2">{tp.order}. {TP_LABEL[tp.type]}</Typography>
-              <Typography variant="body2" whiteSpace="pre-wrap">{tp.summary}</Typography>
+              <Typography variant="subtitle2">
+                {tp.order}. {TP_LABEL[tp.type]}
+              </Typography>
+              <Typography variant="body2" whiteSpace="pre-wrap">
+                {tp.summary}
+              </Typography>
             </Box>
           ))}
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setAiPreview(null)}>Close</Button>
-          <Button variant="contained" onClick={applyPreview}>Apply All</Button>
+          <Button variant="contained" onClick={applyPreview}>
+            Apply All
+          </Button>
         </DialogActions>
       </Dialog>
     </Box>

--- a/src/states/S4CharactersView.tsx
+++ b/src/states/S4CharactersView.tsx
@@ -1,8 +1,24 @@
 // src/states/S4CharactersView.tsx
 import { useMemo, useState } from "react";
 import {
-  Box, Stack, Typography, Paper, Grid, TextField, Select, MenuItem, Button, Chip, Divider, IconButton, Dialog, DialogTitle, DialogContent, DialogActions
+  Box,
+  Stack,
+  Typography,
+  Paper,
+  Grid,
+  TextField,
+  Select,
+  MenuItem,
+  Button,
+  Chip,
+  Divider,
+  IconButton,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
 } from "@mui/material";
+import { useNotify } from "./useNotify";
 import DeleteIcon from "@mui/icons-material/Delete";
 import AddIcon from "@mui/icons-material/Add";
 
@@ -10,17 +26,29 @@ import type { useAppViewModel } from "../vm/useAppViewModel";
 import type { useStateMachine } from "../vm/useStateMachine";
 
 import {
-  STRUCT_ROLES, ARCHETYPES, PHASES,
-  type Character, type Relationship, type JourneyPhase, type Archetype, RELATION_KINDS, type RelationKind
+  STRUCT_ROLES,
+  ARCHETYPES,
+  PHASES,
+  type Character,
+  type Relationship,
+  type JourneyPhase,
+  type Archetype,
+  RELATION_KINDS,
+  type RelationKind,
 } from "../models/characters";
 
 import {
-  proposeCharacters, proposeRelationships
+  proposeCharacters,
+  proposeRelationships,
 } from "../services/aiJobsService";
 
 import {
-  addCharacter, updateCharacter, removeCharacter,
-  addRelationship, updateRelationship, removeRelationship
+  addCharacter,
+  updateCharacter,
+  removeCharacter,
+  addRelationship,
+  updateRelationship,
+  removeRelationship,
 } from "../services/screenplayService";
 
 type VM = ReturnType<typeof useAppViewModel>;
@@ -30,18 +58,25 @@ export default function S4CharactersView({ vm, sm }: { vm: VM; sm: SM }) {
   const sp = vm.screenplay;
   if (!sp) return <Typography variant="body2">Loading screenplay…</Typography>;
 
-  const [charPreview, setCharPreview] = useState<Omit<Character, "id">[] | null>(null);
-  const [relsPreview, setRelsPreview] = useState<Omit<Relationship, "id">[] | null>(null);
+  const [charPreview, setCharPreview] = useState<
+    Omit<Character, "id">[] | null
+  >(null);
+  const [relsPreview, setRelsPreview] = useState<
+    Omit<Relationship, "id">[] | null
+  >(null);
 
   const chars = sp.characters ?? [];
-  const rels  = sp.relationships ?? [];
+  const rels = sp.relationships ?? [];
+  const notify = useNotify();
 
   const stats = useMemo(() => {
-    const roles = new Set(chars.map(c => c.structural_role));
-    const beats = chars.flatMap(c => c.archetype_timeline ?? []);
-    const hasHero   = beats.some(b => b.archetype === "HERO");
-    const hasShadow = beats.some(b => b.archetype === "SHADOW");
-    const hasAllyOrMentor = beats.some(b => b.archetype === "ALLY" || b.archetype === "MENTOR");
+    const roles = new Set(chars.map((c) => c.structural_role));
+    const beats = chars.flatMap((c) => c.archetype_timeline ?? []);
+    const hasHero = beats.some((b) => b.archetype === "HERO");
+    const hasShadow = beats.some((b) => b.archetype === "SHADOW");
+    const hasAllyOrMentor = beats.some(
+      (b) => b.archetype === "ALLY" || b.archetype === "MENTOR",
+    );
     return { count: chars.length, roles, hasHero, hasShadow, hasAllyOrMentor };
   }, [chars]);
 
@@ -50,7 +85,10 @@ export default function S4CharactersView({ vm, sm }: { vm: VM; sm: SM }) {
       name: `Character ${chars.length + 1}`,
       structural_role: "SUPPORTING",
       tags: [],
-      archetype_timeline: PHASES.map(p => ({ phase: p, archetype: "ALLY" as Archetype }))
+      archetype_timeline: PHASES.map((p) => ({
+        phase: p,
+        archetype: "ALLY" as Archetype,
+      })),
     };
     const created = await addCharacter(sp.id, base);
     vm.setScreenplay({ ...sp, characters: [...chars, created] });
@@ -59,19 +97,33 @@ export default function S4CharactersView({ vm, sm }: { vm: VM; sm: SM }) {
 
   const onDeleteCharacter = async (id: number) => {
     await removeCharacter(sp.id, id);
-    vm.setScreenplay({ ...sp, characters: chars.filter(c => c.id !== id), relationships: rels.filter(r => r.a_id !== id && r.b_id !== id) });
+    vm.setScreenplay({
+      ...sp,
+      characters: chars.filter((c) => c.id !== id),
+      relationships: rels.filter((r) => r.a_id !== id && r.b_id !== id),
+    });
     vm.markDirty("S4_CHARACTERS", true);
   };
 
   const editCharacter = async (patch: Character) => {
     const saved = await updateCharacter(sp.id, patch);
-    vm.setScreenplay({ ...sp, characters: chars.map(c => c.id === saved.id ? saved : c) });
+    vm.setScreenplay({
+      ...sp,
+      characters: chars.map((c) => (c.id === saved.id ? saved : c)),
+    });
     vm.markDirty("S4_CHARACTERS", true);
   };
 
   const onAddRelationship = async () => {
     if (chars.length < 2) return;
-    const r: Omit<Relationship, "id"> = { a_id: chars[0].id, b_id: chars[1].id, kind: "ALLY_OF", strength: 0.6, trust: 0.7, secrecy: 0 };
+    const r: Omit<Relationship, "id"> = {
+      a_id: chars[0].id,
+      b_id: chars[1].id,
+      kind: "ALLY_OF",
+      strength: 0.6,
+      trust: 0.7,
+      secrecy: 0,
+    };
     const saved = await addRelationship(sp.id, r);
     vm.setScreenplay({ ...sp, relationships: [...rels, saved] });
     vm.markDirty("S4_CHARACTERS", true);
@@ -79,20 +131,28 @@ export default function S4CharactersView({ vm, sm }: { vm: VM; sm: SM }) {
 
   const onEditRelationship = async (row: Relationship) => {
     const saved = await updateRelationship(sp.id, row);
-    vm.setScreenplay({ ...sp, relationships: rels.map(r => r.id === saved.id ? saved : r) });
+    vm.setScreenplay({
+      ...sp,
+      relationships: rels.map((r) => (r.id === saved.id ? saved : r)),
+    });
     vm.markDirty("S4_CHARACTERS", true);
   };
 
   const onDeleteRelationship = async (id: number) => {
     await removeRelationship(sp.id, id);
-    vm.setScreenplay({ ...sp, relationships: rels.filter(r => r.id !== id) });
+    vm.setScreenplay({ ...sp, relationships: rels.filter((r) => r.id !== id) });
     vm.markDirty("S4_CHARACTERS", true);
   };
 
   const proposeChars = async () => {
     const res = await proposeCharacters(sp.id, {
-      genre: sp.genre, tone: sp.tone, treatment: sp.treatment,
-      turning_points: (sp.turning_points ?? []).map(tp => ({ type: tp.type, summary: tp.summary }))
+      genre: sp.genre,
+      tone: sp.tone,
+      treatment: sp.treatment,
+      turning_points: (sp.turning_points ?? []).map((tp) => ({
+        type: tp.type,
+        summary: tp.summary,
+      })),
     });
     setCharPreview(res.characters);
   };
@@ -100,7 +160,9 @@ export default function S4CharactersView({ vm, sm }: { vm: VM; sm: SM }) {
   const applyCharsPreview = async () => {
     if (!charPreview) return;
     // Reemplaza por simplicidad (puedes implementar merge si quieres)
-    const created = await Promise.all(charPreview.map(c => addCharacter(sp.id, c)));
+    const created = await Promise.all(
+      charPreview.map((c) => addCharacter(sp.id, c)),
+    );
     vm.setScreenplay({ ...sp, characters: created });
     vm.markDirty("S4_CHARACTERS", true);
     setCharPreview(null);
@@ -108,30 +170,47 @@ export default function S4CharactersView({ vm, sm }: { vm: VM; sm: SM }) {
 
   const proposeRels = async () => {
     const res = await proposeRelationships(sp.id, {
-      characters: chars.map(c => ({ name: c.name, structural_role: c.structural_role }))
+      characters: chars.map((c) => ({
+        name: c.name,
+        structural_role: c.structural_role,
+      })),
     });
     // Mapear ids negativos a ids reales por índice (mock)
     // -1 → chars[0], -2 → chars[1], etc. (si existen)
-    const mapId = (tmpId: number) => (tmpId < 0 ? (chars[Math.abs(tmpId) - 1]?.id ?? chars[0].id) : tmpId);
-    setRelsPreview(res.relationships.map(r => ({ ...r, a_id: mapId(r.a_id), b_id: mapId(r.b_id) })));
+    const mapId = (tmpId: number) =>
+      tmpId < 0 ? (chars[Math.abs(tmpId) - 1]?.id ?? chars[0].id) : tmpId;
+    setRelsPreview(
+      res.relationships.map((r) => ({
+        ...r,
+        a_id: mapId(r.a_id),
+        b_id: mapId(r.b_id),
+      })),
+    );
   };
 
   const applyRelsPreview = async () => {
     if (!relsPreview) return;
-    const saved = await Promise.all(relsPreview.map(r => addRelationship(sp.id, r)));
+    const saved = await Promise.all(
+      relsPreview.map((r) => addRelationship(sp.id, r)),
+    );
     vm.setScreenplay({ ...sp, relationships: [...rels, ...saved] });
     vm.markDirty("S4_CHARACTERS", true);
     setRelsPreview(null);
   };
 
   const saveAll = async () => {
-    await vm.saveScreenplay({ characters: sp.characters, relationships: sp.relationships });
+    await vm.saveScreenplay({
+      characters: sp.characters,
+      relationships: sp.relationships,
+    });
   };
 
   const approve = async () => {
     const ok = await sm.requestTransition("S5_SUBPLOTS");
     if (!ok) {
-      alert("Guard fails: need PROTAGONIST + ANTAGONIST, archetypes including HERO and SHADOW, and at least one ALLY or MENTOR.");
+      notify(
+        "Guard fails: need PROTAGONIST + ANTAGONIST, archetypes including HERO and SHADOW, and at least one ALLY or MENTOR.",
+      );
     }
   };
 
@@ -139,29 +218,61 @@ export default function S4CharactersView({ vm, sm }: { vm: VM; sm: SM }) {
     <Box>
       <Stack spacing={2}>
         <Typography variant="body2" color="text.secondary">
-          Define characters (structural role + archetypes per act) and their directed relationships.
+          Define characters (structural role + archetypes per act) and their
+          directed relationships.
         </Typography>
 
         <Stack direction="row" spacing={1} alignItems="center">
-          <Button variant="outlined" onClick={proposeChars}>Propose Characters</Button>
-          <Button variant="outlined" onClick={proposeRels} disabled={(chars.length ?? 0) < 2}>Propose Relationships</Button>
-          <Button variant="contained" onClick={saveAll} disabled={!vm.dirtyByState["S4_CHARACTERS"]}>Save</Button>
-          <Button color="secondary" onClick={approve}>Approve & Continue (→ S5)</Button>
+          <Button variant="outlined" onClick={proposeChars}>
+            Propose Characters
+          </Button>
+          <Button
+            variant="outlined"
+            onClick={proposeRels}
+            disabled={(chars.length ?? 0) < 2}
+          >
+            Propose Relationships
+          </Button>
+          <Button
+            variant="contained"
+            onClick={saveAll}
+            disabled={!vm.dirtyByState["S4_CHARACTERS"]}
+          >
+            Save
+          </Button>
+          <Button color="secondary" onClick={approve}>
+            Approve & Continue (→ S5)
+          </Button>
           <Chip size="small" label={`Chars: ${stats.count}`} />
-          <Chip size="small" label={`Hero:${stats.hasHero ? "✓" : "—"} Shadow:${stats.hasShadow ? "✓" : "—"} Ally/Mentor:${stats.hasAllyOrMentor ? "✓" : "—"}`} />
+          <Chip
+            size="small"
+            label={`Hero:${stats.hasHero ? "✓" : "—"} Shadow:${stats.hasShadow ? "✓" : "—"} Ally/Mentor:${stats.hasAllyOrMentor ? "✓" : "—"}`}
+          />
         </Stack>
 
         {/* Characters */}
         <Paper variant="outlined">
-          <Stack direction="row" alignItems="center" justifyContent="space-between" px={2} py={1}>
+          <Stack
+            direction="row"
+            alignItems="center"
+            justifyContent="space-between"
+            px={2}
+            py={1}
+          >
             <Typography variant="subtitle1">Characters</Typography>
-            <Button startIcon={<AddIcon />} onClick={onAddCharacter}>Add</Button>
+            <Button startIcon={<AddIcon />} onClick={onAddCharacter}>
+              Add
+            </Button>
           </Stack>
           <Divider />
           <Grid container spacing={2} p={2}>
             {(chars ?? []).map((c) => (
               <Grid item xs={12} md={6} key={c.id}>
-                <CharacterCard c={c} onChange={editCharacter} onDelete={onDeleteCharacter} />
+                <CharacterCard
+                  c={c}
+                  onChange={editCharacter}
+                  onDelete={onDeleteCharacter}
+                />
               </Grid>
             ))}
           </Grid>
@@ -169,43 +280,87 @@ export default function S4CharactersView({ vm, sm }: { vm: VM; sm: SM }) {
 
         {/* Relationships */}
         <Paper variant="outlined">
-          <Stack direction="row" alignItems="center" justifyContent="space-between" px={2} py={1}>
+          <Stack
+            direction="row"
+            alignItems="center"
+            justifyContent="space-between"
+            px={2}
+            py={1}
+          >
             <Typography variant="subtitle1">Relationships</Typography>
-            <Button startIcon={<AddIcon />} onClick={onAddRelationship} disabled={(chars.length ?? 0) < 2}>Add</Button>
+            <Button
+              startIcon={<AddIcon />}
+              onClick={onAddRelationship}
+              disabled={(chars.length ?? 0) < 2}
+            >
+              Add
+            </Button>
           </Stack>
           <Divider />
           <Grid container spacing={1} p={2}>
             {(rels ?? []).map((r) => (
-              <RelationshipRow key={r.id} r={r} onChange={onEditRelationship} onDelete={onDeleteRelationship} chars={chars} />
+              <RelationshipRow
+                key={r.id}
+                r={r}
+                onChange={onEditRelationship}
+                onDelete={onDeleteRelationship}
+                chars={chars}
+              />
             ))}
             {rels.length === 0 && (
-              <Grid item xs={12}><Typography variant="body2" color="text.secondary" sx={{ px: 1 }}>No relationships yet.</Typography></Grid>
+              <Grid item xs={12}>
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{ px: 1 }}
+                >
+                  No relationships yet.
+                </Typography>
+              </Grid>
             )}
           </Grid>
         </Paper>
       </Stack>
 
       {/* Preview dialogs */}
-      <Dialog open={!!charPreview} onClose={() => setCharPreview(null)} maxWidth="md" fullWidth>
+      <Dialog
+        open={!!charPreview}
+        onClose={() => setCharPreview(null)}
+        maxWidth="md"
+        fullWidth
+      >
         <DialogTitle>AI Proposal — Characters</DialogTitle>
         <DialogContent dividers>
           {charPreview?.map((c, i) => (
             <Box key={i} mb={2}>
-              <Typography variant="subtitle2">{c.name} — {c.structural_role}</Typography>
-              <Typography variant="body2" color="text.secondary">{c.arc_summary}</Typography>
+              <Typography variant="subtitle2">
+                {c.name} — {c.structural_role}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                {c.arc_summary}
+              </Typography>
               <Typography variant="caption" color="text.secondary">
-                {c.archetype_timeline?.map(b => `${b.phase}:${b.archetype}`).join(" · ")}
+                {c.archetype_timeline
+                  ?.map((b) => `${b.phase}:${b.archetype}`)
+                  .join(" · ")}
               </Typography>
             </Box>
           ))}
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setCharPreview(null)}>Close</Button>
-          <Button variant="contained" onClick={applyCharsPreview}>Apply (replace current)</Button>
+          <Button variant="contained" onClick={applyCharsPreview}>
+            Apply (replace current)
+          </Button>
         </DialogActions>
       </Dialog>
 
-      <Dialog open={!!relsPreview} onClose={() => setRelsPreview(null)} maxWidth="md" fullWidth>
+      <Dialog
+        open={!!relsPreview}
+        onClose={() => setRelsPreview(null)}
+        maxWidth="md"
+        fullWidth
+      >
         <DialogTitle>AI Proposal — Relationships</DialogTitle>
         <DialogContent dividers>
           {relsPreview?.map((r, i) => (
@@ -216,14 +371,20 @@ export default function S4CharactersView({ vm, sm }: { vm: VM; sm: SM }) {
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setRelsPreview(null)}>Close</Button>
-          <Button variant="contained" onClick={applyRelsPreview}>Apply (append)</Button>
+          <Button variant="contained" onClick={applyRelsPreview}>
+            Apply (append)
+          </Button>
         </DialogActions>
       </Dialog>
     </Box>
   );
 }
 
-export function CharacterCard({ c, onChange, onDelete }: {
+export function CharacterCard({
+  c,
+  onChange,
+  onDelete,
+}: {
   c: Character;
   onChange: (c: Character) => void;
   onDelete: (id: number) => void;
@@ -232,7 +393,7 @@ export function CharacterCard({ c, onChange, onDelete }: {
 
   const setBeat = (phase: JourneyPhase, archetype: Archetype) => {
     const beats = [...(c.archetype_timeline ?? [])];
-    const idx = beats.findIndex(b => b.phase === phase);
+    const idx = beats.findIndex((b) => b.phase === phase);
     if (idx >= 0) beats[idx] = { ...beats[idx], archetype };
     else beats.push({ phase, archetype });
     set({ archetype_timeline: beats });
@@ -242,35 +403,105 @@ export function CharacterCard({ c, onChange, onDelete }: {
     <Paper variant="outlined" sx={{ p: 2 }}>
       <Stack direction="row" alignItems="center" justifyContent="space-between">
         <Typography variant="subtitle1">{c.name}</Typography>
-        <IconButton onClick={() => onDelete(c.id)} aria-label="delete character" size="small"><DeleteIcon fontSize="small" /></IconButton>
+        <IconButton
+          onClick={() => onDelete(c.id)}
+          aria-label="delete character"
+          size="small"
+        >
+          <DeleteIcon fontSize="small" />
+        </IconButton>
       </Stack>
 
       <Grid container spacing={1} mt={0.5}>
         <Grid item xs={12} md={6}>
-          <TextField label="Name" value={c.name} onChange={(e) => set({ name: e.target.value })} fullWidth size="small" />
+          <TextField
+            label="Name"
+            value={c.name}
+            onChange={(e) => set({ name: e.target.value })}
+            fullWidth
+            size="small"
+          />
         </Grid>
         <Grid item xs={12} md={6}>
-          <Select fullWidth size="small" value={c.structural_role} onChange={(e) => set({ structural_role: e.target.value as any })}>
-            {STRUCT_ROLES.map(r => <MenuItem key={r} value={r}>{r.replaceAll("_"," ")}</MenuItem>)}
+          <Select
+            fullWidth
+            size="small"
+            value={c.structural_role}
+            onChange={(e) => set({ structural_role: e.target.value as any })}
+          >
+            {STRUCT_ROLES.map((r) => (
+              <MenuItem key={r} value={r}>
+                {r.replaceAll("_", " ")}
+              </MenuItem>
+            ))}
           </Select>
         </Grid>
 
-        <Grid item xs={12} md={4}><TextField label="Goal" value={c.goal ?? ""} onChange={e => set({ goal: e.target.value })} fullWidth size="small" /></Grid>
-        <Grid item xs={12} md={4}><TextField label="Need" value={c.need ?? ""} onChange={e => set({ need: e.target.value })} fullWidth size="small" /></Grid>
-        <Grid item xs={12} md={4}><TextField label="Flaw" value={c.flaw ?? ""} onChange={e => set({ flaw: e.target.value })} fullWidth size="small" /></Grid>
-        <Grid item xs={12}><TextField label="Arc summary" value={c.arc_summary ?? ""} onChange={e => set({ arc_summary: e.target.value })} fullWidth size="small" multiline minRows={2} /></Grid>
+        <Grid item xs={12} md={4}>
+          <TextField
+            label="Goal"
+            value={c.goal ?? ""}
+            onChange={(e) => set({ goal: e.target.value })}
+            fullWidth
+            size="small"
+          />
+        </Grid>
+        <Grid item xs={12} md={4}>
+          <TextField
+            label="Need"
+            value={c.need ?? ""}
+            onChange={(e) => set({ need: e.target.value })}
+            fullWidth
+            size="small"
+          />
+        </Grid>
+        <Grid item xs={12} md={4}>
+          <TextField
+            label="Flaw"
+            value={c.flaw ?? ""}
+            onChange={(e) => set({ flaw: e.target.value })}
+            fullWidth
+            size="small"
+          />
+        </Grid>
+        <Grid item xs={12}>
+          <TextField
+            label="Arc summary"
+            value={c.arc_summary ?? ""}
+            onChange={(e) => set({ arc_summary: e.target.value })}
+            fullWidth
+            size="small"
+            multiline
+            minRows={2}
+          />
+        </Grid>
 
         <Grid item xs={12}>
-          <Typography variant="caption" color="text.secondary">Archetypes per act</Typography>
+          <Typography variant="caption" color="text.secondary">
+            Archetypes per act
+          </Typography>
           <Grid container spacing={1} mt={0.5}>
-            {PHASES.map(p => {
-              const current = c.archetype_timeline?.find(b => b.phase === p)?.archetype ?? "ALLY";
+            {PHASES.map((p) => {
+              const current =
+                c.archetype_timeline?.find((b) => b.phase === p)?.archetype ??
+                "ALLY";
               return (
                 <Grid item xs={12} md={4} key={p}>
-                  <Select fullWidth size="small" value={current} onChange={(e) => setBeat(p, e.target.value as Archetype)}>
-                    {ARCHETYPES.map(a => <MenuItem key={a} value={a}>{a.replaceAll("_"," ")}</MenuItem>)}
+                  <Select
+                    fullWidth
+                    size="small"
+                    value={current}
+                    onChange={(e) => setBeat(p, e.target.value as Archetype)}
+                  >
+                    {ARCHETYPES.map((a) => (
+                      <MenuItem key={a} value={a}>
+                        {a.replaceAll("_", " ")}
+                      </MenuItem>
+                    ))}
                   </Select>
-                  <Typography variant="caption" color="text.secondary">{p.replaceAll("_"," ")}</Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {p.replaceAll("_", " ")}
+                  </Typography>
                 </Grid>
               );
             })}
@@ -281,8 +512,16 @@ export function CharacterCard({ c, onChange, onDelete }: {
           <TextField
             label="Tags (comma-separated)"
             value={(c.tags ?? []).join(", ")}
-            onChange={(e) => set({ tags: e.target.value.split(",").map(s => s.trim()).filter(Boolean) })}
-            fullWidth size="small"
+            onChange={(e) =>
+              set({
+                tags: e.target.value
+                  .split(",")
+                  .map((s) => s.trim())
+                  .filter(Boolean),
+              })
+            }
+            fullWidth
+            size="small"
           />
         </Grid>
       </Grid>
@@ -291,7 +530,10 @@ export function CharacterCard({ c, onChange, onDelete }: {
 }
 
 function RelationshipRow({
-  r, onChange, onDelete, chars
+  r,
+  onChange,
+  onDelete,
+  chars,
 }: {
   r: Relationship;
   onChange: (r: Relationship) => void;
@@ -303,27 +545,74 @@ function RelationshipRow({
   return (
     <Grid container spacing={1} alignItems="center">
       <Grid item xs={12} md={3}>
-        <Select fullWidth size="small" value={r.a_id} onChange={(e) => set({ a_id: Number(e.target.value) })}>
-          {chars.map(c => <MenuItem key={c.id} value={c.id}>{c.name}</MenuItem>)}
+        <Select
+          fullWidth
+          size="small"
+          value={r.a_id}
+          onChange={(e) => set({ a_id: Number(e.target.value) })}
+        >
+          {chars.map((c) => (
+            <MenuItem key={c.id} value={c.id}>
+              {c.name}
+            </MenuItem>
+          ))}
         </Select>
       </Grid>
       <Grid item xs={12} md={4}>
-        <Select fullWidth size="small" value={r.kind} onChange={(e) => set({ kind: e.target.value as RelationKind })}>
-          {RELATION_KINDS.map(k => <MenuItem key={k} value={k}>{k.replaceAll("_"," ")}</MenuItem>)}
+        <Select
+          fullWidth
+          size="small"
+          value={r.kind}
+          onChange={(e) => set({ kind: e.target.value as RelationKind })}
+        >
+          {RELATION_KINDS.map((k) => (
+            <MenuItem key={k} value={k}>
+              {k.replaceAll("_", " ")}
+            </MenuItem>
+          ))}
         </Select>
       </Grid>
       <Grid item xs={12} md={3}>
-        <Select fullWidth size="small" value={r.b_id} onChange={(e) => set({ b_id: Number(e.target.value) })}>
-          {chars.map(c => <MenuItem key={c.id} value={c.id}>{c.name}</MenuItem>)}
+        <Select
+          fullWidth
+          size="small"
+          value={r.b_id}
+          onChange={(e) => set({ b_id: Number(e.target.value) })}
+        >
+          {chars.map((c) => (
+            <MenuItem key={c.id} value={c.id}>
+              {c.name}
+            </MenuItem>
+          ))}
         </Select>
       </Grid>
       <Grid item xs={12} md={1.5}>
-        <TextField label="Strength" size="small" type="number" inputProps={{ step: 0.1, min: 0, max: 1 }} value={r.strength ?? 0} onChange={e => set({ strength: Number(e.target.value) })} />
+        <TextField
+          label="Strength"
+          size="small"
+          type="number"
+          inputProps={{ step: 0.1, min: 0, max: 1 }}
+          value={r.strength ?? 0}
+          onChange={(e) => set({ strength: Number(e.target.value) })}
+        />
       </Grid>
       <Grid item xs={12} md={1.5}>
         <Stack direction="row" alignItems="center" spacing={1}>
-          <TextField label="Trust" size="small" type="number" inputProps={{ step: 0.1, min: 0, max: 1 }} value={r.trust ?? 0} onChange={e => set({ trust: Number(e.target.value) })} />
-          <IconButton aria-label="delete relationship" size="small" onClick={() => onDelete(r.id)}><DeleteIcon fontSize="small" /></IconButton>
+          <TextField
+            label="Trust"
+            size="small"
+            type="number"
+            inputProps={{ step: 0.1, min: 0, max: 1 }}
+            value={r.trust ?? 0}
+            onChange={(e) => set({ trust: Number(e.target.value) })}
+          />
+          <IconButton
+            aria-label="delete relationship"
+            size="small"
+            onClick={() => onDelete(r.id)}
+          >
+            <DeleteIcon fontSize="small" />
+          </IconButton>
         </Stack>
       </Grid>
     </Grid>
@@ -331,6 +620,6 @@ function RelationshipRow({
 }
 
 function labelChar(chars: Character[], id: number) {
-  const c = chars.find(x => x.id === id);
+  const c = chars.find((x) => x.id === id);
   return c ? c.name : `#${id}`;
 }

--- a/src/states/S5SubplotsView.tsx
+++ b/src/states/S5SubplotsView.tsx
@@ -1,9 +1,26 @@
 // src/states/S5SubplotsView.tsx
 import { useMemo, useState } from "react";
 import {
-  Box, Stack, Typography, Paper, Grid, TextField, Select, MenuItem,
-  Button, Chip, IconButton, Divider, Dialog, DialogTitle, DialogContent, DialogActions, Checkbox, ListItemText
+  Box,
+  Stack,
+  Typography,
+  Paper,
+  Grid,
+  TextField,
+  Select,
+  MenuItem,
+  Button,
+  Chip,
+  IconButton,
+  Divider,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Checkbox,
+  ListItemText,
 } from "@mui/material";
+import { useNotify } from "./useNotify";
 import DeleteIcon from "@mui/icons-material/Delete";
 import AddIcon from "@mui/icons-material/Add";
 
@@ -11,15 +28,33 @@ import type { useAppViewModel } from "../vm/useAppViewModel";
 import type { useStateMachine } from "../vm/useStateMachine";
 import type { Subplot, SubplotBeat, SubplotType } from "../models/subplots";
 import type { Character } from "../models/characters";
-import { proposeSubplots, proposeSubplotBeats } from "../services/aiJobsService";
-import { addSubplot, updateSubplot, removeSubplot } from "../services/screenplayService";
+import {
+  proposeSubplots,
+  proposeSubplotBeats,
+} from "../services/aiJobsService";
+import {
+  addSubplot,
+  updateSubplot,
+  removeSubplot,
+} from "../services/screenplayService";
 
 type VM = ReturnType<typeof useAppViewModel>;
 type SM = ReturnType<typeof useStateMachine>;
 
 const SUBPLOT_TYPES: SubplotType[] = [
-  "RELATIONSHIP","ANTAGONIST_POV","INTERNAL_CONFLICT","PROFESSIONAL_MISSION","INVESTIGATION","FAMILY","RIVALRY",
-  "REDEMPTION_OR_REVENGE","THEMATIC_DEBATE","COMIC_RUNNER","BACKSTORY","WORLD_OR_INSTITUTION","SIDE_QUEST"
+  "RELATIONSHIP",
+  "ANTAGONIST_POV",
+  "INTERNAL_CONFLICT",
+  "PROFESSIONAL_MISSION",
+  "INVESTIGATION",
+  "FAMILY",
+  "RIVALRY",
+  "REDEMPTION_OR_REVENGE",
+  "THEMATIC_DEBATE",
+  "COMIC_RUNNER",
+  "BACKSTORY",
+  "WORLD_OR_INSTITUTION",
+  "SIDE_QUEST",
 ];
 
 export default function S5SubplotsView({ vm, sm }: { vm: VM; sm: SM }) {
@@ -31,22 +66,27 @@ export default function S5SubplotsView({ vm, sm }: { vm: VM; sm: SM }) {
   const subplots = sp.subplots ?? [];
   const chars = sp.characters ?? [];
   const tps = sp.turning_points ?? [];
+  const notify = useNotify();
 
-  const stats = useMemo(() => ({
-    count: subplots.length,
-    beats: subplots.reduce((acc, s) => acc + (s.beats?.length ?? 0), 0),
-    withTP: subplots.filter(s => (s.linkedTurningPoints?.length ?? 0) > 0).length
-  }), [subplots]);
+  const stats = useMemo(
+    () => ({
+      count: subplots.length,
+      beats: subplots.reduce((acc, s) => acc + (s.beats?.length ?? 0), 0),
+      withTP: subplots.filter((s) => (s.linkedTurningPoints?.length ?? 0) > 0)
+        .length,
+    }),
+    [subplots],
+  );
 
   const onAdd = async () => {
     const base: Omit<Subplot, "id"> = {
       title: `Subplot ${subplots.length + 1}`,
       type: "RELATIONSHIP",
       purpose: "",
-      dominantActs: ["ACT_I","ACT_II"],
+      dominantActs: ["ACT_I", "ACT_II"],
       charactersInvolved: [],
       linkedTurningPoints: [],
-      beats: []
+      beats: [],
     };
     const created = await addSubplot(sp.id, base);
     vm.setScreenplay({ ...sp, subplots: [...subplots, created] });
@@ -55,22 +95,30 @@ export default function S5SubplotsView({ vm, sm }: { vm: VM; sm: SM }) {
 
   const onRemove = async (id: number) => {
     await removeSubplot(sp.id, id);
-    vm.setScreenplay({ ...sp, subplots: subplots.filter(s => s.id !== id) });
+    vm.setScreenplay({ ...sp, subplots: subplots.filter((s) => s.id !== id) });
     vm.markDirty("S5_SUBPLOTS", true);
   };
 
   const onChange = async (s: Subplot) => {
     const saved = await updateSubplot(sp.id, s);
-    vm.setScreenplay({ ...sp, subplots: subplots.map(x => x.id === s.id ? saved : x) });
+    vm.setScreenplay({
+      ...sp,
+      subplots: subplots.map((x) => (x.id === s.id ? saved : x)),
+    });
     vm.markDirty("S5_SUBPLOTS", true);
   };
 
   const propose = async () => {
     const res = await proposeSubplots(sp.id, {
       treatment: sp.treatment,
-      turning_points: tps.map(tp => ({ type: tp.type, summary: tp.summary })),
-      characters: chars.map(c => ({ id: c.id, name: c.name, structural_role: c.structural_role })),
-      genre: sp.genre, tone: sp.tone
+      turning_points: tps.map((tp) => ({ type: tp.type, summary: tp.summary })),
+      characters: chars.map((c) => ({
+        id: c.id,
+        name: c.name,
+        structural_role: c.structural_role,
+      })),
+      genre: sp.genre,
+      tone: sp.tone,
     });
     setPreview(res.subplots);
   };
@@ -78,7 +126,7 @@ export default function S5SubplotsView({ vm, sm }: { vm: VM; sm: SM }) {
   const applyPreviewReplace = async () => {
     if (!preview) return;
     // crea todas de cero (mock)
-    const created = await Promise.all(preview.map(p => addSubplot(sp.id, p)));
+    const created = await Promise.all(preview.map((p) => addSubplot(sp.id, p)));
     vm.setScreenplay({ ...sp, subplots: created });
     vm.markDirty("S5_SUBPLOTS", true);
     setPreview(null);
@@ -91,7 +139,9 @@ export default function S5SubplotsView({ vm, sm }: { vm: VM; sm: SM }) {
   const approve = async () => {
     const ok = await sm.requestTransition("S6_KEY_SCENES");
     if (!ok) {
-      alert("Guard fails: need >=1 subplot with beats & characters; and at least one subplot linked to a Turning Point.");
+      notify(
+        "Guard fails: need >=1 subplot with beats & characters; and at least one subplot linked to a Turning Point.",
+      );
     }
   };
 
@@ -99,26 +149,45 @@ export default function S5SubplotsView({ vm, sm }: { vm: VM; sm: SM }) {
     <Box>
       <Stack spacing={2}>
         <Typography variant="body2" color="text.secondary">
-          Design secondary plotlines. Each subplot should have beats that change something and, ideally, connect to Turning Points.
+          Design secondary plotlines. Each subplot should have beats that change
+          something and, ideally, connect to Turning Points.
         </Typography>
 
         <Stack direction="row" spacing={1} alignItems="center">
-          <Button variant="outlined" onClick={propose}>Propose Subplots</Button>
-          <Button variant="contained" onClick={saveAll} disabled={!vm.dirtyByState["S5_SUBPLOTS"]}>Save</Button>
-          <Button color="secondary" onClick={approve}>Approve & Continue (→ S6)</Button>
+          <Button variant="outlined" onClick={propose}>
+            Propose Subplots
+          </Button>
+          <Button
+            variant="contained"
+            onClick={saveAll}
+            disabled={!vm.dirtyByState["S5_SUBPLOTS"]}
+          >
+            Save
+          </Button>
+          <Button color="secondary" onClick={approve}>
+            Approve & Continue (→ S6)
+          </Button>
           <Chip size="small" label={`Subplots: ${stats.count}`} />
           <Chip size="small" label={`Beats total: ${stats.beats}`} />
           <Chip size="small" label={`Linked to TPs: ${stats.withTP}`} />
         </Stack>
 
         <Paper variant="outlined">
-          <Stack direction="row" alignItems="center" justifyContent="space-between" px={2} py={1}>
+          <Stack
+            direction="row"
+            alignItems="center"
+            justifyContent="space-between"
+            px={2}
+            py={1}
+          >
             <Typography variant="subtitle1">Subplots</Typography>
-            <Button startIcon={<AddIcon />} onClick={onAdd}>Add</Button>
+            <Button startIcon={<AddIcon />} onClick={onAdd}>
+              Add
+            </Button>
           </Stack>
           <Divider />
           <Grid container spacing={2} p={2}>
-            {subplots.map(spo => (
+            {subplots.map((spo) => (
               <Grid item xs={12} key={spo.id}>
                 <SubplotCard
                   s={spo}
@@ -131,20 +200,31 @@ export default function S5SubplotsView({ vm, sm }: { vm: VM; sm: SM }) {
             ))}
             {subplots.length === 0 && (
               <Grid item xs={12}>
-                <Typography variant="body2" color="text.secondary">No subplots yet.</Typography>
+                <Typography variant="body2" color="text.secondary">
+                  No subplots yet.
+                </Typography>
               </Grid>
             )}
           </Grid>
         </Paper>
       </Stack>
 
-      <Dialog open={!!preview} onClose={() => setPreview(null)} maxWidth="md" fullWidth>
+      <Dialog
+        open={!!preview}
+        onClose={() => setPreview(null)}
+        maxWidth="md"
+        fullWidth
+      >
         <DialogTitle>AI Proposal — Subplots</DialogTitle>
         <DialogContent dividers>
           {preview?.map((s, i) => (
             <Box key={i} mb={2}>
-              <Typography variant="subtitle2">{s.title} — {s.type}</Typography>
-              <Typography variant="body2" color="text.secondary">{s.purpose}</Typography>
+              <Typography variant="subtitle2">
+                {s.title} — {s.type}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                {s.purpose}
+              </Typography>
               <Typography variant="caption" color="text.secondary">
                 Acts: {s.dominantActs.join(", ")} · Beats: {s.beats.length}
               </Typography>
@@ -153,7 +233,9 @@ export default function S5SubplotsView({ vm, sm }: { vm: VM; sm: SM }) {
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setPreview(null)}>Close</Button>
-          <Button variant="contained" onClick={applyPreviewReplace}>Apply (replace current)</Button>
+          <Button variant="contained" onClick={applyPreviewReplace}>
+            Apply (replace current)
+          </Button>
         </DialogActions>
       </Dialog>
     </Box>
@@ -161,7 +243,11 @@ export default function S5SubplotsView({ vm, sm }: { vm: VM; sm: SM }) {
 }
 
 export function SubplotCard({
-  s, onChange, onRemove, characters, turningPointsCount
+  s,
+  onChange,
+  onRemove,
+  characters,
+  turningPointsCount,
 }: {
   s: Subplot;
   onChange: (s: Subplot) => void;
@@ -171,26 +257,30 @@ export function SubplotCard({
 }) {
   const set = (patch: Partial<Subplot>) => onChange({ ...s, ...patch });
 
-  const toggleAct = (act: "ACT_I"|"ACT_II"|"ACT_III") => {
+  const toggleAct = (act: "ACT_I" | "ACT_II" | "ACT_III") => {
     const has = s.dominantActs.includes(act);
-    const next = has ? s.dominantActs.filter(a => a !== act) : [...s.dominantActs, act];
+    const next = has
+      ? s.dominantActs.filter((a) => a !== act)
+      : [...s.dominantActs, act];
     set({ dominantActs: next });
   };
 
   const addBeat = () => {
     const next = [...(s.beats ?? [])];
-    const ord = next.length ? Math.max(...next.map(b => b.order)) + 1 : 1;
+    const ord = next.length ? Math.max(...next.map((b) => b.order)) + 1 : 1;
     next.push({ order: ord, summary: "" });
     set({ beats: next });
   };
 
   const editBeat = (idx: number, patch: Partial<SubplotBeat>) => {
-    const next = s.beats.map((b, i) => i === idx ? { ...b, ...patch } : b);
+    const next = s.beats.map((b, i) => (i === idx ? { ...b, ...patch } : b));
     set({ beats: next });
   };
 
   const delBeat = (idx: number) => {
-    const next = s.beats.filter((_, i) => i !== idx).map((b, i) => ({ ...b, order: i + 1 }));
+    const next = s.beats
+      .filter((_, i) => i !== idx)
+      .map((b, i) => ({ ...b, order: i + 1 }));
     set({ beats: next });
   };
 
@@ -200,8 +290,10 @@ export function SubplotCard({
       type: s.type,
       purpose: s.purpose,
       dominantActs: s.dominantActs,
-      charactersInvolved: characters.filter(c => s.charactersInvolved.includes(c.id)).map(c => c.name),
-      constraints: []
+      charactersInvolved: characters
+        .filter((c) => s.charactersInvolved.includes(c.id))
+        .map((c) => c.name),
+      constraints: [],
     });
     set({ beats: res.beats });
   };
@@ -209,17 +301,40 @@ export function SubplotCard({
   return (
     <Paper variant="outlined" sx={{ p: 2 }}>
       <Stack direction="row" alignItems="center" justifyContent="space-between">
-        <Typography variant="subtitle1">{s.title || "Untitled Subplot"}</Typography>
-        <IconButton aria-label="delete subplot" size="small" onClick={() => onRemove(s.id)}><DeleteIcon fontSize="small" /></IconButton>
+        <Typography variant="subtitle1">
+          {s.title || "Untitled Subplot"}
+        </Typography>
+        <IconButton
+          aria-label="delete subplot"
+          size="small"
+          onClick={() => onRemove(s.id)}
+        >
+          <DeleteIcon fontSize="small" />
+        </IconButton>
       </Stack>
 
       <Grid container spacing={1} mt={0.5}>
         <Grid item xs={12} md={6}>
-          <TextField label="Title" value={s.title} onChange={(e) => set({ title: e.target.value })} fullWidth size="small" />
+          <TextField
+            label="Title"
+            value={s.title}
+            onChange={(e) => set({ title: e.target.value })}
+            fullWidth
+            size="small"
+          />
         </Grid>
         <Grid item xs={12} md={3}>
-          <Select fullWidth size="small" value={s.type} onChange={(e) => set({ type: e.target.value as SubplotType })}>
-            {SUBPLOT_TYPES.map(t => <MenuItem key={t} value={t}>{t.replaceAll("_"," ")}</MenuItem>)}
+          <Select
+            fullWidth
+            size="small"
+            value={s.type}
+            onChange={(e) => set({ type: e.target.value as SubplotType })}
+          >
+            {SUBPLOT_TYPES.map((t) => (
+              <MenuItem key={t} value={t}>
+                {t.replaceAll("_", " ")}
+              </MenuItem>
+            ))}
           </Select>
         </Grid>
         <Grid item xs={12} md={3}>
@@ -227,7 +342,13 @@ export function SubplotCard({
         </Grid>
 
         <Grid item xs={12}>
-          <TextField label="Purpose" value={s.purpose} onChange={(e) => set({ purpose: e.target.value })} fullWidth size="small" />
+          <TextField
+            label="Purpose"
+            value={s.purpose}
+            onChange={(e) => set({ purpose: e.target.value })}
+            fullWidth
+            size="small"
+          />
         </Grid>
 
         <Grid item xs={12} md={6}>
@@ -246,34 +367,77 @@ export function SubplotCard({
         </Grid>
 
         <Grid item xs={12}>
-          <Stack direction="row" alignItems="center" justifyContent="space-between">
+          <Stack
+            direction="row"
+            alignItems="center"
+            justifyContent="space-between"
+          >
             <Typography variant="subtitle2">Beats</Typography>
             <Stack direction="row" spacing={1}>
-              <Button variant="outlined" onClick={addBeat} startIcon={<AddIcon />}>Add beat</Button>
-              <Button variant="outlined" onClick={proposeBeats}>Propose beats</Button>
+              <Button
+                variant="outlined"
+                onClick={addBeat}
+                startIcon={<AddIcon />}
+              >
+                Add beat
+              </Button>
+              <Button variant="outlined" onClick={proposeBeats}>
+                Propose beats
+              </Button>
             </Stack>
           </Stack>
           <Box sx={{ mt: 1 }}>
             {s.beats.map((b, idx) => (
-              <Grid container spacing={1} alignItems="center" key={idx} sx={{ mb: 1 }}>
+              <Grid
+                container
+                spacing={1}
+                alignItems="center"
+                key={idx}
+                sx={{ mb: 1 }}
+              >
                 <Grid item xs={12} md={1.2}>
-                  <TextField label="Order" size="small" type="number" value={b.order}
-                    onChange={(e) => editBeat(idx, { order: Number(e.target.value) })} />
+                  <TextField
+                    label="Order"
+                    size="small"
+                    type="number"
+                    value={b.order}
+                    onChange={(e) =>
+                      editBeat(idx, { order: Number(e.target.value) })
+                    }
+                  />
                 </Grid>
                 <Grid item xs={12} md={7}>
-                  <TextField label="Summary" size="small" value={b.summary}
-                    onChange={(e) => editBeat(idx, { summary: e.target.value })} fullWidth />
+                  <TextField
+                    label="Summary"
+                    size="small"
+                    value={b.summary}
+                    onChange={(e) => editBeat(idx, { summary: e.target.value })}
+                    fullWidth
+                  />
                 </Grid>
                 <Grid item xs={12} md={3.3}>
-                  <TextField label="Out change" size="small" value={b.outChange ?? ""}
-                    onChange={(e) => editBeat(idx, { outChange: e.target.value })} fullWidth />
+                  <TextField
+                    label="Out change"
+                    size="small"
+                    value={b.outChange ?? ""}
+                    onChange={(e) =>
+                      editBeat(idx, { outChange: e.target.value })
+                    }
+                    fullWidth
+                  />
                 </Grid>
                 <Grid item xs={12} md={0.5}>
-                  <IconButton size="small" onClick={() => delBeat(idx)}><DeleteIcon fontSize="small" /></IconButton>
+                  <IconButton size="small" onClick={() => delBeat(idx)}>
+                    <DeleteIcon fontSize="small" />
+                  </IconButton>
                 </Grid>
               </Grid>
             ))}
-            {s.beats.length === 0 && <Typography variant="body2" color="text.secondary">No beats yet.</Typography>}
+            {s.beats.length === 0 && (
+              <Typography variant="body2" color="text.secondary">
+                No beats yet.
+              </Typography>
+            )}
           </Box>
         </Grid>
       </Grid>
@@ -281,16 +445,24 @@ export function SubplotCard({
   );
 }
 
-function ActsToggles({ value, onToggle }: {
-  value: ("ACT_I"|"ACT_II"|"ACT_III")[];
-  onToggle: (a: "ACT_I"|"ACT_II"|"ACT_III") => void;
+function ActsToggles({
+  value,
+  onToggle,
+}: {
+  value: ("ACT_I" | "ACT_II" | "ACT_III")[];
+  onToggle: (a: "ACT_I" | "ACT_II" | "ACT_III") => void;
 }) {
-  const acts: ("ACT_I"|"ACT_II"|"ACT_III")[] = ["ACT_I","ACT_II","ACT_III"];
+  const acts: ("ACT_I" | "ACT_II" | "ACT_III")[] = [
+    "ACT_I",
+    "ACT_II",
+    "ACT_III",
+  ];
   return (
     <Stack direction="row" spacing={1} sx={{ flexWrap: "wrap" }}>
-      {acts.map(a => (
-        <Chip key={a}
-          label={a.replaceAll("_"," ")}
+      {acts.map((a) => (
+        <Chip
+          key={a}
+          label={a.replaceAll("_", " ")}
           variant={value.includes(a) ? "filled" : "outlined"}
           onClick={() => onToggle(a)}
           size="small"
@@ -301,7 +473,9 @@ function ActsToggles({ value, onToggle }: {
 }
 
 function MultiSelectCharacters({
-  value, onChange, characters
+  value,
+  onChange,
+  characters,
 }: {
   value: number[];
   onChange: (ids: number[]) => void;
@@ -309,12 +483,19 @@ function MultiSelectCharacters({
 }) {
   return (
     <Select
-      multiple fullWidth size="small"
+      multiple
+      fullWidth
+      size="small"
       value={value}
       onChange={(e) => onChange((e.target.value as number[]) || [])}
-      renderValue={(selected) => characters.filter(c => selected.includes(c.id)).map(c => c.name).join(", ")}
+      renderValue={(selected) =>
+        characters
+          .filter((c) => selected.includes(c.id))
+          .map((c) => c.name)
+          .join(", ")
+      }
     >
-      {characters.map(c => (
+      {characters.map((c) => (
         <MenuItem key={c.id} value={c.id}>
           <Checkbox checked={value.includes(c.id)} />
           <ListItemText primary={c.name} />
@@ -325,7 +506,9 @@ function MultiSelectCharacters({
 }
 
 function MultiSelectTPs({
-  value, onChange, count
+  value,
+  onChange,
+  count,
 }: {
   value: number[];
   onChange: (ids: number[]) => void;
@@ -334,12 +517,16 @@ function MultiSelectTPs({
   const options = Array.from({ length: count }, (_, i) => i + 1);
   return (
     <Select
-      multiple fullWidth size="small"
+      multiple
+      fullWidth
+      size="small"
       value={value}
       onChange={(e) => onChange((e.target.value as number[]) || [])}
-      renderValue={(selected) => (selected as number[]).sort((a,b)=>a-b).join(", ")}
+      renderValue={(selected) =>
+        (selected as number[]).sort((a, b) => a - b).join(", ")
+      }
     >
-      {options.map(n => (
+      {options.map((n) => (
         <MenuItem key={n} value={n}>
           <Checkbox checked={value.includes(n)} />
           <ListItemText primary={`TP #${n}`} />

--- a/src/states/S6KeyScenesView.tsx
+++ b/src/states/S6KeyScenesView.tsx
@@ -1,10 +1,24 @@
 // src/states/S6KeyScenesView.tsx
 import { useMemo, useState, useEffect } from "react";
 import {
-  Box, Stack, Typography, Paper, Grid, TextField, Select, MenuItem,
-  Button, Chip, IconButton, Divider,
-  Dialog, DialogTitle, DialogContent, DialogActions
+  Box,
+  Stack,
+  Typography,
+  Paper,
+  Grid,
+  TextField,
+  Select,
+  MenuItem,
+  Button,
+  Chip,
+  IconButton,
+  Divider,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
 } from "@mui/material";
+import { useNotify } from "./useNotify";
 import DeleteIcon from "@mui/icons-material/Delete";
 import AddIcon from "@mui/icons-material/Add";
 
@@ -12,7 +26,11 @@ import type { useAppViewModel } from "../vm/useAppViewModel";
 import type { useStateMachine } from "../vm/useStateMachine";
 import type { Scene, Heading, DayPart } from "../models/scenes";
 import { proposeKeyScenes, proposeSceneForTP } from "../services/aiJobsService";
-import { addScene, updateScene, removeScene } from "../services/screenplayService";
+import {
+  addScene,
+  updateScene,
+  removeScene,
+} from "../services/screenplayService";
 
 type VM = ReturnType<typeof useAppViewModel>;
 type SM = ReturnType<typeof useStateMachine>;
@@ -26,17 +44,25 @@ export default function S6KeyScenesView({ vm, sm }: { vm: VM; sm: SM }) {
 
   const tps = sp.turning_points ?? [];
   const scenes = useMemo(
-    () => (sp.scenes ?? []).filter(s => s.is_key).sort((a,b)=>a.order-b.order),
-    [sp.scenes]
+    () =>
+      (sp.scenes ?? [])
+        .filter((s) => s.is_key)
+        .sort((a, b) => a.order - b.order),
+    [sp.scenes],
   );
 
-  const stats = useMemo(() => ({
-    count: scenes.length,
-    covered: new Set(scenes.map(s => s.linked_turning_point)).size,
-    need: tps.length
-  }), [scenes, tps]);
+  const stats = useMemo(
+    () => ({
+      count: scenes.length,
+      covered: new Set(scenes.map((s) => s.linked_turning_point)).size,
+      need: tps.length,
+    }),
+    [scenes, tps],
+  );
 
-  const [preview, setPreview] = useState<Omit<Scene,"id"|"order">[]|null>(null);
+  const [preview, setPreview] = useState<Omit<Scene, "id" | "order">[] | null>(
+    null,
+  );
 
   // Focus visual cuando aterrizas desde S9 (TP chip)
   const [focusTP, setFocusTP] = useState<number | null>(null);
@@ -49,9 +75,12 @@ export default function S6KeyScenesView({ vm, sm }: { vm: VM; sm: SM }) {
         const t = setTimeout(() => setFocusTP(null), 3000);
         return () => clearTimeout(t);
       }
-    } catch { /* noop */ }
+    } catch {
+      /* noop */
+    }
   }, []);
 
+  const notify = useNotify();
   const addForTP = async (tpOrder: number) => {
     const created = await addScene(sp.id, {
       title: `Key Scene #${tpOrder}`,
@@ -61,15 +90,25 @@ export default function S6KeyScenesView({ vm, sm }: { vm: VM; sm: SM }) {
       location: "",
       time_of_day: "DAY",
       synopsis: "",
-      goal: "", conflict: "", outcome: "",
-      characters: []
+      goal: "",
+      conflict: "",
+      outcome: "",
+      characters: [],
     });
     vm.setScreenplay({ ...sp, scenes: [...(sp.scenes ?? []), created] });
     vm.markDirty("S6_KEY_SCENES", true);
   };
 
-  const proposeForTP = async (tpOrder: number, tpType: string, tpSummary: string) => {
-    const s = await proposeSceneForTP(sp.id, { tp_order: tpOrder, tp_type: tpType, tp_summary: tpSummary });
+  const proposeForTP = async (
+    tpOrder: number,
+    tpType: string,
+    tpSummary: string,
+  ) => {
+    const s = await proposeSceneForTP(sp.id, {
+      tp_order: tpOrder,
+      tp_type: tpType,
+      tp_summary: tpSummary,
+    });
     const created = await addScene(sp.id, s);
     vm.setScreenplay({ ...sp, scenes: [...(sp.scenes ?? []), created] });
     vm.markDirty("S6_KEY_SCENES", true);
@@ -78,16 +117,25 @@ export default function S6KeyScenesView({ vm, sm }: { vm: VM; sm: SM }) {
   const proposeAll = async () => {
     const res = await proposeKeyScenes(sp.id, {
       treatment: sp.treatment,
-      turning_points: tps.map(tp => ({ order: tp.order, type: tp.type, summary: tp.summary })),
-      characters: (sp.characters ?? []).map(c => ({ id: c.id, name: c.name, structural_role: c.structural_role })),
-      genre: sp.genre, tone: sp.tone
+      turning_points: tps.map((tp) => ({
+        order: tp.order,
+        type: tp.type,
+        summary: tp.summary,
+      })),
+      characters: (sp.characters ?? []).map((c) => ({
+        id: c.id,
+        name: c.name,
+        structural_role: c.structural_role,
+      })),
+      genre: sp.genre,
+      tone: sp.tone,
     });
     setPreview(res.scenes);
   };
 
   const applyPreview = async () => {
     if (!preview) return;
-    const created = await Promise.all(preview.map(p => addScene(sp.id, p)));
+    const created = await Promise.all(preview.map((p) => addScene(sp.id, p)));
     vm.setScreenplay({ ...sp, scenes: [...(sp.scenes ?? []), ...created] });
     vm.markDirty("S6_KEY_SCENES", true);
     setPreview(null);
@@ -95,13 +143,19 @@ export default function S6KeyScenesView({ vm, sm }: { vm: VM; sm: SM }) {
 
   const onChange = async (s: Scene) => {
     const saved = await updateScene(sp.id, s);
-    vm.setScreenplay({ ...sp, scenes: (sp.scenes ?? []).map(x => x.id === s.id ? saved : x) });
+    vm.setScreenplay({
+      ...sp,
+      scenes: (sp.scenes ?? []).map((x) => (x.id === s.id ? saved : x)),
+    });
     vm.markDirty("S6_KEY_SCENES", true);
   };
 
   const onRemove = async (id: number) => {
     await removeScene(sp.id, id);
-    vm.setScreenplay({ ...sp, scenes: (sp.scenes ?? []).filter(x => x.id !== id) });
+    vm.setScreenplay({
+      ...sp,
+      scenes: (sp.scenes ?? []).filter((x) => x.id !== id),
+    });
     vm.markDirty("S6_KEY_SCENES", true);
   };
 
@@ -112,7 +166,9 @@ export default function S6KeyScenesView({ vm, sm }: { vm: VM; sm: SM }) {
   const approve = async () => {
     const ok = await sm.requestTransition("S7_ALL_SCENES");
     if (!ok) {
-      alert("Guard fails: need coverage (≥1 key scene per TP) and synopsis ≥ 40 characters.");
+      notify(
+        "Guard fails: need coverage (≥1 key scene per TP) and synopsis ≥ 40 characters.",
+      );
     }
   };
 
@@ -120,20 +176,40 @@ export default function S6KeyScenesView({ vm, sm }: { vm: VM; sm: SM }) {
     <Box>
       <Stack spacing={2}>
         <Typography variant="body2" color="text.secondary">
-          Plan the key scenes that land each Turning Point. One or more per TP; each with G/C/O (Goal/Conflict/Outcome).
+          Plan the key scenes that land each Turning Point. One or more per TP;
+          each with G/C/O (Goal/Conflict/Outcome).
         </Typography>
 
         <Stack direction="row" spacing={1} alignItems="center">
-          <Button variant="outlined" onClick={proposeAll} disabled={!tps.length}>Propose All from Turning Points</Button>
-          <Button variant="contained" onClick={saveAll} disabled={!vm.dirtyByState["S6_KEY_SCENES"]}>Save</Button>
-          <Button color="secondary" onClick={approve}>Approve & Continue (→ S7)</Button>
+          <Button
+            variant="outlined"
+            onClick={proposeAll}
+            disabled={!tps.length}
+          >
+            Propose All from Turning Points
+          </Button>
+          <Button
+            variant="contained"
+            onClick={saveAll}
+            disabled={!vm.dirtyByState["S6_KEY_SCENES"]}
+          >
+            Save
+          </Button>
+          <Button color="secondary" onClick={approve}>
+            Approve & Continue (→ S7)
+          </Button>
           <Chip size="small" label={`Key scenes: ${stats.count}`} />
-          <Chip size="small" label={`TP covered: ${stats.covered}/${stats.need || "-"}`} />
+          <Chip
+            size="small"
+            label={`TP covered: ${stats.covered}/${stats.need || "-"}`}
+          />
         </Stack>
 
         {/* Lista por TP */}
-        {tps.map(tp => {
-          const items = scenes.filter(s => s.linked_turning_point === tp.order);
+        {tps.map((tp) => {
+          const items = scenes.filter(
+            (s) => s.linked_turning_point === tp.order,
+          );
           return (
             <Paper
               key={tp.order}
@@ -141,23 +217,53 @@ export default function S6KeyScenesView({ vm, sm }: { vm: VM; sm: SM }) {
               sx={{
                 p: 2,
                 borderColor: focusTP === tp.order ? "warning.main" : "divider",
-                boxShadow: focusTP === tp.order ? 2 : 0
+                boxShadow: focusTP === tp.order ? 2 : 0,
               }}
             >
-              <Stack direction="row" alignItems="center" justifyContent="space-between">
-                <Typography variant="subtitle1">TP#{tp.order} — {tp.type}</Typography>
+              <Stack
+                direction="row"
+                alignItems="center"
+                justifyContent="space-between"
+              >
+                <Typography variant="subtitle1">
+                  TP#{tp.order} — {tp.type}
+                </Typography>
                 <Stack direction="row" spacing={1}>
-                  <Button size="small" variant="outlined" startIcon={<AddIcon />} onClick={() => addForTP(tp.order)}>Add scene</Button>
-                  <Button size="small" variant="outlined" onClick={() => proposeForTP(tp.order, tp.type, tp.summary)}>Propose scene</Button>
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    startIcon={<AddIcon />}
+                    onClick={() => addForTP(tp.order)}
+                  >
+                    Add scene
+                  </Button>
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    onClick={() => proposeForTP(tp.order, tp.type, tp.summary)}
+                  >
+                    Propose scene
+                  </Button>
                 </Stack>
               </Stack>
-              <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>{tp.summary}</Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                {tp.summary}
+              </Typography>
 
-              {items.length === 0 && <Typography variant="body2" color="text.secondary">No key scenes for this TP yet.</Typography>}
+              {items.length === 0 && (
+                <Typography variant="body2" color="text.secondary">
+                  No key scenes for this TP yet.
+                </Typography>
+              )}
 
               <Stack spacing={1.5}>
-                {items.map(s => (
-                  <SceneRow key={s.id} scene={s} onChange={onChange} onRemove={onRemove} />
+                {items.map((s) => (
+                  <SceneRow
+                    key={s.id}
+                    scene={s}
+                    onChange={onChange}
+                    onRemove={onRemove}
+                  />
                 ))}
               </Stack>
             </Paper>
@@ -166,26 +272,41 @@ export default function S6KeyScenesView({ vm, sm }: { vm: VM; sm: SM }) {
       </Stack>
 
       {/* Preview dialog */}
-      <Dialog open={!!preview} onClose={() => setPreview(null)} maxWidth="md" fullWidth>
+      <Dialog
+        open={!!preview}
+        onClose={() => setPreview(null)}
+        maxWidth="md"
+        fullWidth
+      >
         <DialogTitle>AI Proposal — Key Scenes</DialogTitle>
         <DialogContent dividers>
           {preview?.map((p, i) => (
             <Box key={i} mb={2}>
-              <Typography variant="subtitle2">{p.title} (TP#{p.linked_turning_point})</Typography>
-              <Typography variant="body2" whiteSpace="pre-wrap">{p.synopsis}</Typography>
+              <Typography variant="subtitle2">
+                {p.title} (TP#{p.linked_turning_point})
+              </Typography>
+              <Typography variant="body2" whiteSpace="pre-wrap">
+                {p.synopsis}
+              </Typography>
             </Box>
           ))}
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setPreview(null)}>Close</Button>
-          <Button variant="contained" onClick={applyPreview}>Apply (append)</Button>
+          <Button variant="contained" onClick={applyPreview}>
+            Apply (append)
+          </Button>
         </DialogActions>
       </Dialog>
     </Box>
   );
 }
 
-function SceneRow({ scene, onChange, onRemove }: {
+function SceneRow({
+  scene,
+  onChange,
+  onRemove,
+}: {
   scene: Scene;
   onChange: (s: Scene) => void;
   onRemove: (id: number) => void;
@@ -195,32 +316,97 @@ function SceneRow({ scene, onChange, onRemove }: {
     <Paper variant="outlined" sx={{ p: 1.5 }}>
       <Grid container spacing={1} alignItems="center">
         <Grid item xs={12} md={2.2}>
-          <TextField size="small" label="Title" value={scene.title ?? ""} onChange={e => set({ title: e.target.value })} />
+          <TextField
+            size="small"
+            label="Title"
+            value={scene.title ?? ""}
+            onChange={(e) => set({ title: e.target.value })}
+          />
         </Grid>
         <Grid item xs={12} md={1.8}>
-          <Select size="small" fullWidth value={scene.heading ?? "INT"} onChange={e => set({ heading: e.target.value as Heading })}>
-            {HEADINGS.map(h => <MenuItem key={h} value={h}>{h}</MenuItem>)}
+          <Select
+            size="small"
+            fullWidth
+            value={scene.heading ?? "INT"}
+            onChange={(e) => set({ heading: e.target.value as Heading })}
+          >
+            {HEADINGS.map((h) => (
+              <MenuItem key={h} value={h}>
+                {h}
+              </MenuItem>
+            ))}
           </Select>
         </Grid>
         <Grid item xs={12} md={3}>
-          <TextField size="small" label="Location" value={scene.location ?? ""} onChange={e => set({ location: e.target.value })} fullWidth />
+          <TextField
+            size="small"
+            label="Location"
+            value={scene.location ?? ""}
+            onChange={(e) => set({ location: e.target.value })}
+            fullWidth
+          />
         </Grid>
         <Grid item xs={12} md={1.5}>
-          <Select size="small" fullWidth value={scene.time_of_day ?? "DAY"} onChange={e => set({ time_of_day: e.target.value as DayPart })}>
-            {TIMES.map(t => <MenuItem key={t} value={t}>{t}</MenuItem>)}
+          <Select
+            size="small"
+            fullWidth
+            value={scene.time_of_day ?? "DAY"}
+            onChange={(e) => set({ time_of_day: e.target.value as DayPart })}
+          >
+            {TIMES.map((t) => (
+              <MenuItem key={t} value={t}>
+                {t}
+              </MenuItem>
+            ))}
           </Select>
         </Grid>
         <Grid item xs={12} md={3.5}>
-          <TextField size="small" label="Synopsis" value={scene.synopsis} onChange={e => set({ synopsis: e.target.value })} fullWidth />
+          <TextField
+            size="small"
+            label="Synopsis"
+            value={scene.synopsis}
+            onChange={(e) => set({ synopsis: e.target.value })}
+            fullWidth
+          />
         </Grid>
         <Grid item xs={12} md={0.6}>
-          <IconButton size="small" onClick={() => onRemove(scene.id)} aria-label="delete"><DeleteIcon fontSize="small" /></IconButton>
+          <IconButton
+            size="small"
+            onClick={() => onRemove(scene.id)}
+            aria-label="delete"
+          >
+            <DeleteIcon fontSize="small" />
+          </IconButton>
         </Grid>
       </Grid>
       <Grid container spacing={1} mt={0.5}>
-        <Grid item xs={12} md={4}><TextField size="small" label="Goal" value={scene.goal ?? ""} onChange={e => set({ goal: e.target.value })} fullWidth /></Grid>
-        <Grid item xs={12} md={4}><TextField size="small" label="Conflict" value={scene.conflict ?? ""} onChange={e => set({ conflict: e.target.value })} fullWidth /></Grid>
-        <Grid item xs={12} md={4}><TextField size="small" label="Outcome" value={scene.outcome ?? ""} onChange={e => set({ outcome: e.target.value })} fullWidth /></Grid>
+        <Grid item xs={12} md={4}>
+          <TextField
+            size="small"
+            label="Goal"
+            value={scene.goal ?? ""}
+            onChange={(e) => set({ goal: e.target.value })}
+            fullWidth
+          />
+        </Grid>
+        <Grid item xs={12} md={4}>
+          <TextField
+            size="small"
+            label="Conflict"
+            value={scene.conflict ?? ""}
+            onChange={(e) => set({ conflict: e.target.value })}
+            fullWidth
+          />
+        </Grid>
+        <Grid item xs={12} md={4}>
+          <TextField
+            size="small"
+            label="Outcome"
+            value={scene.outcome ?? ""}
+            onChange={(e) => set({ outcome: e.target.value })}
+            fullWidth
+          />
+        </Grid>
       </Grid>
     </Paper>
   );

--- a/src/states/S7AllScenesView.tsx
+++ b/src/states/S7AllScenesView.tsx
@@ -1,9 +1,20 @@
 // src/states/S7AllScenesView.tsx
 import { useMemo, useState } from "react";
 import {
-  Box, Stack, Typography, Paper, Grid, TextField, Select, MenuItem,
-  Button, Chip, IconButton, Divider
+  Box,
+  Stack,
+  Typography,
+  Paper,
+  Grid,
+  TextField,
+  Select,
+  MenuItem,
+  Button,
+  Chip,
+  IconButton,
+  Divider,
 } from "@mui/material";
+import { useNotify } from "./useNotify";
 import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
 import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
 import AddIcon from "@mui/icons-material/Add";
@@ -12,7 +23,13 @@ import DeleteIcon from "@mui/icons-material/Delete";
 import type { useAppViewModel } from "../vm/useAppViewModel";
 import type { useStateMachine } from "../vm/useStateMachine";
 import type { Scene, Heading, DayPart } from "../models/scenes";
-import { addScene, updateScene, removeScene, reorderScenes, moveScene } from "../services/screenplayService";
+import {
+  addScene,
+  updateScene,
+  removeScene,
+  reorderScenes,
+  moveScene,
+} from "../services/screenplayService";
 import { proposeNonKeyScenes } from "../services/aiJobsService";
 
 type VM = ReturnType<typeof useAppViewModel>;
@@ -25,16 +42,20 @@ export default function S7AllScenesView({ vm, sm }: { vm: VM; sm: SM }) {
   const sp = vm.screenplay;
   if (!sp) return <Typography variant="body2">Loading screenplay…</Typography>;
 
-  const scenes = (sp.scenes ?? []).slice().sort((a,b)=>a.order-b.order);
+  const scenes = (sp.scenes ?? []).slice().sort((a, b) => a.order - b.order);
   const tps = sp.turning_points ?? [];
 
-  const stats = useMemo(() => ({
-    total: scenes.length,
-    key: scenes.filter(s => s.is_key).length,
-    nonKey: scenes.filter(s => !s.is_key).length
-  }), [scenes]);
+  const stats = useMemo(
+    () => ({
+      total: scenes.length,
+      key: scenes.filter((s) => s.is_key).length,
+      nonKey: scenes.filter((s) => !s.is_key).length,
+    }),
+    [scenes],
+  );
 
   const [proposing, setProposing] = useState(false);
+  const notify = useNotify();
 
   const addSceneBelow = async (afterOrder: number) => {
     // Añade y reordena (lo sencillo en mock: insertar al final y luego reordenar ordenes)
@@ -46,13 +67,15 @@ export default function S7AllScenesView({ vm, sm }: { vm: VM; sm: SM }) {
       location: "",
       time_of_day: "DAY",
       synopsis: "",
-      goal: "", conflict: "", outcome: "",
-      characters: []
+      goal: "",
+      conflict: "",
+      outcome: "",
+      characters: [],
     });
     const ids = scenes
-      .flatMap(s => s.order <= afterOrder ? [s.id] : [])
+      .flatMap((s) => (s.order <= afterOrder ? [s.id] : []))
       .concat([created.id])
-      .concat(scenes.filter(s => s.order > afterOrder).map(s => s.id));
+      .concat(scenes.filter((s) => s.order > afterOrder).map((s) => s.id));
     const updated = await reorderScenes(sp.id, ids);
     vm.setScreenplay({ ...sp, scenes: updated });
     vm.markDirty("S7_ALL_SCENES", true);
@@ -60,7 +83,12 @@ export default function S7AllScenesView({ vm, sm }: { vm: VM; sm: SM }) {
 
   const remove = async (id: number) => {
     await removeScene(sp.id, id);
-    vm.setScreenplay({ ...sp, scenes: (sp.scenes ?? []).filter(s => s.id !== id).map((s, i) => ({ ...s, order: i + 1 })) });
+    vm.setScreenplay({
+      ...sp,
+      scenes: (sp.scenes ?? [])
+        .filter((s) => s.id !== id)
+        .map((s, i) => ({ ...s, order: i + 1 })),
+    });
     vm.markDirty("S7_ALL_SCENES", true);
   };
 
@@ -72,7 +100,10 @@ export default function S7AllScenesView({ vm, sm }: { vm: VM; sm: SM }) {
 
   const onChange = async (s: Scene) => {
     const saved = await updateScene(sp.id, s);
-    vm.setScreenplay({ ...sp, scenes: (sp.scenes ?? []).map(x => x.id === s.id ? saved : x) });
+    vm.setScreenplay({
+      ...sp,
+      scenes: (sp.scenes ?? []).map((x) => (x.id === s.id ? saved : x)),
+    });
     vm.markDirty("S7_ALL_SCENES", true);
   };
 
@@ -81,17 +112,33 @@ export default function S7AllScenesView({ vm, sm }: { vm: VM; sm: SM }) {
     try {
       const res = await proposeNonKeyScenes(sp.id, {
         treatment: sp.treatment,
-        turning_points: tps.map(tp => ({ order: tp.order, type: tp.type, summary: tp.summary })),
-        subplots: (sp.subplots ?? []).map(s => ({ title: s.title, type: s.type, beats: s.beats })),
-        existing: scenes.map(s => ({ is_key: s.is_key, linked_turning_point: s.linked_turning_point })),
-        targetCount: 40, genre: sp.genre, tone: sp.tone
+        turning_points: tps.map((tp) => ({
+          order: tp.order,
+          type: tp.type,
+          summary: tp.summary,
+        })),
+        subplots: (sp.subplots ?? []).map((s) => ({
+          title: s.title,
+          type: s.type,
+          beats: s.beats,
+        })),
+        existing: scenes.map((s) => ({
+          is_key: s.is_key,
+          linked_turning_point: s.linked_turning_point,
+        })),
+        targetCount: 40,
+        genre: sp.genre,
+        tone: sp.tone,
       });
       // apéndalas al final
       for (const p of res.scenes) {
         const created = await addScene(sp.id, p);
         sp.scenes = [...(sp.scenes ?? []), created];
       }
-      vm.setScreenplay({ ...sp, scenes: (sp.scenes ?? []).slice().sort((a,b)=>a.order-b.order) });
+      vm.setScreenplay({
+        ...sp,
+        scenes: (sp.scenes ?? []).slice().sort((a, b) => a.order - b.order),
+      });
       vm.markDirty("S7_ALL_SCENES", true);
     } finally {
       setProposing(false);
@@ -105,7 +152,9 @@ export default function S7AllScenesView({ vm, sm }: { vm: VM; sm: SM }) {
   const approve = async () => {
     const ok = await sm.requestTransition("S8_FORMATTED_DRAFT");
     if (!ok) {
-      alert("Guard fails: ensure contiguous numbering, meta filled (heading/location/time) and all key TPs covered with ≥30-char synopsis.");
+      notify(
+        "Guard fails: ensure contiguous numbering, meta filled (heading/location/time) and all key TPs covered with ≥30-char synopsis.",
+      );
     }
   };
 
@@ -113,22 +162,45 @@ export default function S7AllScenesView({ vm, sm }: { vm: VM; sm: SM }) {
     <Box>
       <Stack spacing={2}>
         <Typography variant="body2" color="text.secondary">
-          Complete the scene list (key and non-key). You can add, edit and reorder. Use AI to propose connective scenes.
+          Complete the scene list (key and non-key). You can add, edit and
+          reorder. Use AI to propose connective scenes.
         </Typography>
 
         <Stack direction="row" spacing={1} alignItems="center">
-          <Button variant="outlined" onClick={proposeNonKey} disabled={proposing}>Propose non-key scenes</Button>
-          <Button variant="contained" onClick={saveAll} disabled={!vm.dirtyByState["S7_ALL_SCENES"]}>Save</Button>
-          <Button color="secondary" onClick={approve}>Approve & Continue (→ S8)</Button>
+          <Button
+            variant="outlined"
+            onClick={proposeNonKey}
+            disabled={proposing}
+          >
+            Propose non-key scenes
+          </Button>
+          <Button
+            variant="contained"
+            onClick={saveAll}
+            disabled={!vm.dirtyByState["S7_ALL_SCENES"]}
+          >
+            Save
+          </Button>
+          <Button color="secondary" onClick={approve}>
+            Approve & Continue (→ S8)
+          </Button>
           <Chip size="small" label={`Total: ${stats.total}`} />
           <Chip size="small" label={`Key: ${stats.key}`} />
           <Chip size="small" label={`Non-key: ${stats.nonKey}`} />
         </Stack>
 
         <Paper variant="outlined">
-          <Stack direction="row" alignItems="center" justifyContent="space-between" px={2} py={1}>
+          <Stack
+            direction="row"
+            alignItems="center"
+            justifyContent="space-between"
+            px={2}
+            py={1}
+          >
             <Typography variant="subtitle1">Scenes</Typography>
-            <Typography variant="caption" color="text.secondary">Use the arrows to reorder; add below any scene.</Typography>
+            <Typography variant="caption" color="text.secondary">
+              Use the arrows to reorder; add below any scene.
+            </Typography>
           </Stack>
           <Divider />
           <Box sx={{ p: 2 }}>
@@ -146,7 +218,9 @@ export default function S7AllScenesView({ vm, sm }: { vm: VM; sm: SM }) {
                 />
               ))}
               {scenes.length === 0 && (
-                <Typography variant="body2" color="text.secondary">No scenes yet. Start by adding or proposing.</Typography>
+                <Typography variant="body2" color="text.secondary">
+                  No scenes yet. Start by adding or proposing.
+                </Typography>
               )}
             </Stack>
           </Box>
@@ -157,14 +231,20 @@ export default function S7AllScenesView({ vm, sm }: { vm: VM; sm: SM }) {
 }
 
 function SceneRow({
-  scene, isFirst, isLast, onChange, onRemove, onMove, onAddBelow
+  scene,
+  isFirst,
+  isLast,
+  onChange,
+  onRemove,
+  onMove,
+  onAddBelow,
 }: {
   scene: Scene;
   isFirst: boolean;
   isLast: boolean;
   onChange: (s: Scene) => void;
   onRemove: (id: number) => void;
-  onMove: (id: number, dir: "UP"|"DOWN") => void;
+  onMove: (id: number, dir: "UP" | "DOWN") => void;
   onAddBelow: () => void;
 }) {
   const set = (patch: Partial<Scene>) => onChange({ ...scene, ...patch });
@@ -175,34 +255,92 @@ function SceneRow({
           <Chip size="small" label={scene.order} />
         </Grid>
         <Grid item xs={12} md={1.4}>
-          {scene.is_key ? <Chip size="small" color="warning" label={`TP#${scene.linked_turning_point ?? "-"}`} /> : <Chip size="small" variant="outlined" label="non-key" />}
+          {scene.is_key ? (
+            <Chip
+              size="small"
+              color="warning"
+              label={`TP#${scene.linked_turning_point ?? "-"}`}
+            />
+          ) : (
+            <Chip size="small" variant="outlined" label="non-key" />
+          )}
         </Grid>
         <Grid item xs={12} md={1.8}>
-          <Select size="small" fullWidth value={scene.heading ?? "INT"} onChange={e => set({ heading: e.target.value as Heading })}>
-            {HEADINGS.map(h => <MenuItem key={h} value={h}>{h}</MenuItem>)}
+          <Select
+            size="small"
+            fullWidth
+            value={scene.heading ?? "INT"}
+            onChange={(e) => set({ heading: e.target.value as Heading })}
+          >
+            {HEADINGS.map((h) => (
+              <MenuItem key={h} value={h}>
+                {h}
+              </MenuItem>
+            ))}
           </Select>
         </Grid>
         <Grid item xs={12} md={2.5}>
-          <TextField size="small" label="Location" value={scene.location ?? ""} onChange={e => set({ location: e.target.value })} fullWidth />
+          <TextField
+            size="small"
+            label="Location"
+            value={scene.location ?? ""}
+            onChange={(e) => set({ location: e.target.value })}
+            fullWidth
+          />
         </Grid>
         <Grid item xs={12} md={1.4}>
-          <Select size="small" fullWidth value={scene.time_of_day ?? "DAY"} onChange={e => set({ time_of_day: e.target.value as DayPart })}>
-            {TIMES.map(t => <MenuItem key={t} value={t}>{t}</MenuItem>)}
+          <Select
+            size="small"
+            fullWidth
+            value={scene.time_of_day ?? "DAY"}
+            onChange={(e) => set({ time_of_day: e.target.value as DayPart })}
+          >
+            {TIMES.map((t) => (
+              <MenuItem key={t} value={t}>
+                {t}
+              </MenuItem>
+            ))}
           </Select>
         </Grid>
         <Grid item xs={12} md={3.5}>
-          <TextField size="small" label="Synopsis" value={scene.synopsis} onChange={e => set({ synopsis: e.target.value })} fullWidth />
+          <TextField
+            size="small"
+            label="Synopsis"
+            value={scene.synopsis}
+            onChange={(e) => set({ synopsis: e.target.value })}
+            fullWidth
+          />
         </Grid>
         <Grid item xs={12} md={0.6}>
           <Stack direction="row" spacing={0.5}>
-            <IconButton size="small" disabled={isFirst} onClick={() => onMove(scene.id, "UP")}><ArrowUpwardIcon fontSize="small" /></IconButton>
-            <IconButton size="small" disabled={isLast} onClick={() => onMove(scene.id, "DOWN")}><ArrowDownwardIcon fontSize="small" /></IconButton>
+            <IconButton
+              size="small"
+              disabled={isFirst}
+              onClick={() => onMove(scene.id, "UP")}
+            >
+              <ArrowUpwardIcon fontSize="small" />
+            </IconButton>
+            <IconButton
+              size="small"
+              disabled={isLast}
+              onClick={() => onMove(scene.id, "DOWN")}
+            >
+              <ArrowDownwardIcon fontSize="small" />
+            </IconButton>
           </Stack>
         </Grid>
         <Grid item xs={12} md={0.6}>
           <Stack direction="row" spacing={0.5}>
-            <IconButton size="small" onClick={onAddBelow} title="Add below"><AddIcon fontSize="small" /></IconButton>
-            <IconButton size="small" onClick={() => onRemove(scene.id)} title="Delete"><DeleteIcon fontSize="small" /></IconButton>
+            <IconButton size="small" onClick={onAddBelow} title="Add below">
+              <AddIcon fontSize="small" />
+            </IconButton>
+            <IconButton
+              size="small"
+              onClick={() => onRemove(scene.id)}
+              title="Delete"
+            >
+              <DeleteIcon fontSize="small" />
+            </IconButton>
           </Stack>
         </Grid>
       </Grid>

--- a/src/states/S8FormattedDraftView.tsx
+++ b/src/states/S8FormattedDraftView.tsx
@@ -1,8 +1,18 @@
 // src/states/S8FormattedDraftView.tsx
 import { useMemo, useState } from "react";
 import {
-  Box, Stack, Typography, Paper, Grid, TextField, Button, Chip, IconButton, Divider
+  Box,
+  Stack,
+  Typography,
+  Paper,
+  Grid,
+  TextField,
+  Button,
+  Chip,
+  IconButton,
+  Divider,
 } from "@mui/material";
+import { useNotify } from "./useNotify";
 import AutoFixHighIcon from "@mui/icons-material/AutoFixHigh";
 import SaveIcon from "@mui/icons-material/Save";
 import DownloadIcon from "@mui/icons-material/Download";
@@ -23,25 +33,43 @@ export default function S8FormattedDraftView({ vm, sm }: { vm: VM; sm: SM }) {
   if (!sp) return <Typography variant="body2">Loading screenplay…</Typography>;
 
   const scenes = (sp.scenes ?? []).slice().sort((a, b) => a.order - b.order);
-  const keyCount = scenes.filter(s => s.is_key).length;
-  const coveredKeys = scenes.filter(s => s.is_key && (s.formatted_text?.trim().length ?? 0) >= 60).length;
-  const drafted = scenes.filter(s => (s.formatted_text?.trim().length ?? 0) >= 40).length;
+  const keyCount = scenes.filter((s) => s.is_key).length;
+  const coveredKeys = scenes.filter(
+    (s) => s.is_key && (s.formatted_text?.trim().length ?? 0) >= 60,
+  ).length;
+  const drafted = scenes.filter(
+    (s) => (s.formatted_text?.trim().length ?? 0) >= 40,
+  ).length;
 
   const [busyId, setBusyId] = useState<number | null>(null);
+  const notify = useNotify();
 
   const proposeFor = async (sc: Scene) => {
     setBusyId(sc.id);
     try {
       const charNames = (sp.characters ?? [])
-        .filter(c => (sc.characters ?? []).includes(c.id))
-        .map(c => c.name);
+        .filter((c) => (sc.characters ?? []).includes(c.id))
+        .map((c) => c.name);
       const { fountain } = await proposeSceneDraft(sp.id, sc.id, {
-        heading: sc.heading, location: sc.location, time_of_day: sc.time_of_day,
-        title: sc.title, synopsis: sc.synopsis, goal: sc.goal, conflict: sc.conflict, outcome: sc.outcome,
-        characterNames: charNames, style: { pacing: "LEAN" }
+        heading: sc.heading,
+        location: sc.location,
+        time_of_day: sc.time_of_day,
+        title: sc.title,
+        synopsis: sc.synopsis,
+        goal: sc.goal,
+        conflict: sc.conflict,
+        outcome: sc.outcome,
+        characterNames: charNames,
+        style: { pacing: "LEAN" },
       });
-      const saved = await updateScene(sp.id, { ...sc, formatted_text: fountain });
-      vm.setScreenplay({ ...sp, scenes: (sp.scenes ?? []).map(x => x.id === sc.id ? saved : x) });
+      const saved = await updateScene(sp.id, {
+        ...sc,
+        formatted_text: fountain,
+      });
+      vm.setScreenplay({
+        ...sp,
+        scenes: (sp.scenes ?? []).map((x) => (x.id === sc.id ? saved : x)),
+      });
       vm.markDirty("S8_FORMATTED_DRAFT", true);
     } finally {
       setBusyId(null);
@@ -60,7 +88,9 @@ export default function S8FormattedDraftView({ vm, sm }: { vm: VM; sm: SM }) {
   const approve = async () => {
     const ok = await sm.requestTransition("S9_REVIEW");
     if (!ok) {
-      alert("Guard fails: key scenes need proper drafts (≥60 chars), and most scenes (≥60%) should have ≥40 chars.");
+      notify(
+        "Guard fails: key scenes need proper drafts (≥60 chars), and most scenes (≥60%) should have ≥40 chars.",
+      );
     }
   };
 
@@ -68,21 +98,51 @@ export default function S8FormattedDraftView({ vm, sm }: { vm: VM; sm: SM }) {
     <Box>
       <Stack spacing={2}>
         <Typography variant="body2" color="text.secondary">
-          Format each scene in <strong>Fountain</strong>. Start with key scenes, then fill the rest. You can ask AI to propose a draft.
+          Format each scene in <strong>Fountain</strong>. Start with key scenes,
+          then fill the rest. You can ask AI to propose a draft.
         </Typography>
 
         <Stack direction="row" spacing={1} alignItems="center">
-          <Button variant="outlined" startIcon={<DownloadIcon />} onClick={compile}>Compile & Download (.fountain)</Button>
-          <Button variant="contained" startIcon={<SaveIcon />} onClick={saveAll} disabled={!vm.dirtyByState["S8_FORMATTED_DRAFT"]}>Save</Button>
-          <Button color="secondary" startIcon={<CheckIcon />} onClick={approve}>Approve & Continue (→ S9)</Button>
-          <Chip size="small" label={`Scenes drafted: ${drafted}/${scenes.length}`} />
-          <Chip size="small" label={`Key drafted: ${coveredKeys}/${keyCount}`} />
+          <Button
+            variant="outlined"
+            startIcon={<DownloadIcon />}
+            onClick={compile}
+          >
+            Compile & Download (.fountain)
+          </Button>
+          <Button
+            variant="contained"
+            startIcon={<SaveIcon />}
+            onClick={saveAll}
+            disabled={!vm.dirtyByState["S8_FORMATTED_DRAFT"]}
+          >
+            Save
+          </Button>
+          <Button color="secondary" startIcon={<CheckIcon />} onClick={approve}>
+            Approve & Continue (→ S9)
+          </Button>
+          <Chip
+            size="small"
+            label={`Scenes drafted: ${drafted}/${scenes.length}`}
+          />
+          <Chip
+            size="small"
+            label={`Key drafted: ${coveredKeys}/${keyCount}`}
+          />
         </Stack>
 
         <Paper variant="outlined">
-          <Stack direction="row" alignItems="center" justifyContent="space-between" px={2} py={1}>
+          <Stack
+            direction="row"
+            alignItems="center"
+            justifyContent="space-between"
+            px={2}
+            py={1}
+          >
             <Typography variant="subtitle1">Scenes (formatted text)</Typography>
-            <Typography variant="caption" color="text.secondary">Tip: Fountain supports SLUGS, dialogue blocks, transitions, etc.</Typography>
+            <Typography variant="caption" color="text.secondary">
+              Tip: Fountain supports SLUGS, dialogue blocks, transitions, etc.
+            </Typography>
           </Stack>
           <Divider />
           <Box sx={{ p: 2 }}>
@@ -93,14 +153,23 @@ export default function S8FormattedDraftView({ vm, sm }: { vm: VM; sm: SM }) {
                   sc={s}
                   onChange={async (next) => {
                     const saved = await updateScene(sp.id, next);
-                    vm.setScreenplay({ ...sp, scenes: (sp.scenes ?? []).map(x => x.id === next.id ? saved : x) });
+                    vm.setScreenplay({
+                      ...sp,
+                      scenes: (sp.scenes ?? []).map((x) =>
+                        x.id === next.id ? saved : x,
+                      ),
+                    });
                     vm.markDirty("S8_FORMATTED_DRAFT", true);
                   }}
                   onPropose={() => proposeFor(s)}
                   loading={busyId === s.id}
                 />
               ))}
-              {scenes.length === 0 && <Typography variant="body2" color="text.secondary">No scenes loaded.</Typography>}
+              {scenes.length === 0 && (
+                <Typography variant="body2" color="text.secondary">
+                  No scenes loaded.
+                </Typography>
+              )}
             </Stack>
           </Box>
         </Paper>
@@ -110,7 +179,10 @@ export default function S8FormattedDraftView({ vm, sm }: { vm: VM; sm: SM }) {
 }
 
 export function SceneEditor({
-  sc, onChange, onPropose, loading
+  sc,
+  onChange,
+  onPropose,
+  loading,
 }: {
   sc: Scene;
   onChange: (s: Scene) => void;
@@ -121,11 +193,28 @@ export function SceneEditor({
   const badge = isKey ? `TP#${sc.linked_turning_point ?? "-"}` : "non-key";
   return (
     <Paper variant="outlined" sx={{ p: 1.5 }}>
-      <Stack direction="row" spacing={1} alignItems="center" justifyContent="space-between" mb={1}>
-        <Typography variant="subtitle2">#{sc.order} — {sc.title || "Untitled"} {isKey ? "· Key" : ""}</Typography>
+      <Stack
+        direction="row"
+        spacing={1}
+        alignItems="center"
+        justifyContent="space-between"
+        mb={1}
+      >
+        <Typography variant="subtitle2">
+          #{sc.order} — {sc.title || "Untitled"} {isKey ? "· Key" : ""}
+        </Typography>
         <Stack direction="row" spacing={1} alignItems="center">
-          <Chip size="small" color={isKey ? "warning" : "default"} label={badge} />
-          <Button size="small" startIcon={<AutoFixHighIcon />} onClick={onPropose} disabled={loading}>
+          <Chip
+            size="small"
+            color={isKey ? "warning" : "default"}
+            label={badge}
+          />
+          <Button
+            size="small"
+            startIcon={<AutoFixHighIcon />}
+            onClick={onPropose}
+            disabled={loading}
+          >
             Propose draft
           </Button>
         </Stack>
@@ -135,9 +224,13 @@ export function SceneEditor({
           <TextField
             label="Fountain (formatted text for this scene)"
             value={sc.formatted_text ?? ""}
-            onChange={(e) => onChange({ ...sc, formatted_text: e.target.value })}
-            multiline minRows={6} fullWidth
-            placeholder={`e.g.\n${(sc.heading ?? "INT")}. ${(sc.location ?? "LOCATION").toUpperCase()} - ${(sc.time_of_day ?? "DAY").toUpperCase()}\n\nAction line...\n\nCHARACTER NAME\nDialogue...\n`}
+            onChange={(e) =>
+              onChange({ ...sc, formatted_text: e.target.value })
+            }
+            multiline
+            minRows={6}
+            fullWidth
+            placeholder={`e.g.\n${sc.heading ?? "INT"}. ${(sc.location ?? "LOCATION").toUpperCase()} - ${(sc.time_of_day ?? "DAY").toUpperCase()}\n\nAction line...\n\nCHARACTER NAME\nDialogue...\n`}
           />
         </Grid>
       </Grid>

--- a/src/states/useNotify.tsx
+++ b/src/states/useNotify.tsx
@@ -1,0 +1,30 @@
+import { create } from "zustand";
+import { Snackbar, Alert } from "@mui/material";
+
+interface NotifyState {
+  message: string | null;
+  notify: (msg: string) => void;
+  clear: () => void;
+}
+
+const useNotifyStore = create<NotifyState>((set) => ({
+  message: null,
+  notify: (msg) => set({ message: msg }),
+  clear: () => set({ message: null }),
+}));
+
+export function useNotify() {
+  return useNotifyStore((s) => s.notify);
+}
+
+export function NotifySnackbar() {
+  const message = useNotifyStore((s) => s.message);
+  const clear = useNotifyStore((s) => s.clear);
+  return (
+    <Snackbar open={!!message} autoHideDuration={4000} onClose={clear}>
+      <Alert onClose={clear} severity="error" variant="filled">
+        {message}
+      </Alert>
+    </Snackbar>
+  );
+}


### PR DESCRIPTION
## Summary
- add `useNotify` store and global `NotifySnackbar`
- replace `alert()` calls in state views with new `notify`

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: 153 problems)*
- `npm run check:types` *(fails: compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_689a2bcd72f883329af15ffe9a4c9a90