### PR TITLE
feat: add navigation drawer

### DIFF
--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,14 +1,46 @@
 // src/layouts/MainLayout.tsx
-import { AppBar, Toolbar, Typography, Box, Container, IconButton } from "@mui/material";
+import {
+  AppBar,
+  Toolbar,
+  Typography,
+  Box,
+  Container,
+  IconButton,
+  Drawer,
+  List,
+  ListItemButton,
+  ListItemText,
+} from "@mui/material";
 import MenuIcon from "@mui/icons-material/Menu";
-import { PropsWithChildren } from "react";
+import { PropsWithChildren, useState } from "react";
 
 export function MainLayout({ children }: PropsWithChildren) {
+  const [open, setOpen] = useState(false);
+
   return (
     <Box sx={{ display: "grid", minHeight: "100dvh", gridTemplateRows: "64px 1fr" }}>
+      <Drawer open={open} onClose={() => setOpen(false)}>
+        <List>
+          {[
+            "Home",
+            "Settings",
+            "Help",
+          ].map((text) => (
+            <ListItemButton key={text} onClick={() => setOpen(false)}>
+              <ListItemText primary={text} />
+            </ListItemButton>
+          ))}
+        </List>
+      </Drawer>
+
       <AppBar position="sticky" color="inherit">
         <Toolbar>
-          <IconButton edge="start" aria-label="menu" size="small">
+          <IconButton
+            edge="start"
+            aria-label="menu"
+            size="small"
+            onClick={() => setOpen(true)}
+          >
             <MenuIcon />
           </IconButton>
           <Typography variant="h6" sx={{ ml: 1, fontWeight: 600 }}>


### PR DESCRIPTION
## Summary
- add navigation drawer with Home, Settings, Help items
- open drawer from menu icon and close on selection or outside click

## Testing
- `npm test` (fails: No test files found)
- `npm run lint` (fails: existing lint errors)


------
https://chatgpt.com/codex/tasks/task_e_689a2bcda5ac833281f6b4e946c59108