### PR TITLE
Add React Router with screenplay route

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,5 +1,6 @@
 // src/app/App.tsx
 import { ThemeProvider, CssBaseline } from "@mui/material";
+import { Routes, Route, Navigate } from "react-router-dom";
 import { theme } from "./theme";
 import { MainLayout } from "../layouts/MainLayout";
 import ScreenplayPage from "../pages/ScreenplayPage";
@@ -9,7 +10,10 @@ export default function App() {
     <ThemeProvider theme={theme}>
       <CssBaseline />
       <MainLayout>
-        <ScreenplayPage />
+        <Routes>
+          <Route path="/screenplays/:id" element={<ScreenplayPage />} />
+          <Route path="*" element={<Navigate to="/screenplays/1" replace />} />
+        </Routes>
       </MainLayout>
     </ThemeProvider>
   );

--- a/src/components/ScreenplayTabs.tsx
+++ b/src/components/ScreenplayTabs.tsx
@@ -1,75 +1,96 @@
 // src/components/ScreenplayTabs.tsx
 import { Tabs, Tab, Badge, Box, Tooltip } from "@mui/material";
+import { NavLink, useParams } from "react-router-dom";
 import { STATES, type StateId } from "../models/enums";
 
-const INDEX: Record<StateId, number> = STATES.reduce((acc, s, i) => {
-    acc[s] = i; return acc;
-}, {} as Record<StateId, number>);
+const INDEX: Record<StateId, number> = STATES.reduce(
+  (acc, s, i) => {
+    acc[s] = i;
+    return acc;
+  },
+  {} as Record<StateId, number>,
+);
 
 type Props = {
-    current: StateId;
-    onChange: (s: StateId) => void;
-    dirtyByState?: Partial<Record<StateId, boolean>>;
-    desyncByState?: Partial<Record<StateId, boolean>>;
-    canEnter?: (s: StateId) => boolean;
+  current: StateId;
+  onChange: (s: StateId) => void;
+  dirtyByState?: Partial<Record<StateId, boolean>>;
+  desyncByState?: Partial<Record<StateId, boolean>>;
+  canEnter?: (s: StateId) => boolean;
 };
 
 export function ScreenplayTabs({
-    current,
-    onChange,
-    dirtyByState = {},
-    desyncByState = {},
-    canEnter = () => true
+  current,
+  onChange,
+  dirtyByState = {},
+  desyncByState = {},
+  canEnter = () => true,
 }: Props) {
-    const currentIndex = STATES.includes(current) ? INDEX[current] : 0;
+  const currentIndex = STATES.includes(current) ? INDEX[current] : 0;
+  const { id } = useParams<{ id: string }>();
 
-    const handleChange = (_: unknown, valueIndex: number) => {
-        const next = STATES[valueIndex];
-        if (!next) return;
-        if (!canEnter(next)) return;
-        onChange(next);
-    };
+  const handleChange = (_: unknown, valueIndex: number) => {
+    const next = STATES[valueIndex];
+    if (!next) return;
+    if (!canEnter(next)) return;
+    onChange(next);
+  };
 
-    return (
-        <Box sx={{ borderBottom: "1px solid", borderColor: "divider" }}>
-            <Tabs
-                value={currentIndex}
-                onChange={handleChange}
-                variant="scrollable"
-                allowScrollButtonsMobile
+  return (
+    <Box sx={{ borderBottom: "1px solid", borderColor: "divider" }}>
+      <Tabs
+        value={currentIndex}
+        onChange={handleChange}
+        variant="scrollable"
+        allowScrollButtonsMobile
+      >
+        {STATES.map((s, i) => {
+          const dirty = !!dirtyByState[s];
+          const desync = !!desyncByState[s];
+
+          // Importante: no deshabilitar el tab actualmente seleccionado
+          const disabled = i !== currentIndex && !canEnter(s);
+
+          const color = dirty
+            ? "warning"
+            : desync
+              ? "secondary"
+              : ("default" as any);
+          const label = (
+            <Badge
+              color={color}
+              variant={dirty || desync ? "dot" : "standard"}
+              overlap="circular"
             >
-                {STATES.map((s, i) => {
-                    const dirty = !!dirtyByState[s];
-                    const desync = !!desyncByState[s];
+              <span>{s.replace("_", " ")}</span>
+            </Badge>
+          );
 
-                    // Importante: no deshabilitar el tab actualmente seleccionado
-                    const disabled = i !== currentIndex && !canEnter(s);
-
-                    const color = dirty ? "warning" : desync ? "secondary" : ("default" as any);
-                    const label = (
-                        <Badge color={color} variant={dirty || desync ? "dot" : "standard"} overlap="circular">
-                            <span>{s.replace("_", " ")}</span>
-                        </Badge>
-                    );
-
-                    return (
-                        <Tooltip
-                            key={s}
-                            title={
-                                disabled
-                                    ? "Locked by previous state guards"
-                                    : dirty
-                                        ? "Unsaved changes"
-                                        : desync
-                                            ? "Out-of-date due to upstream edits"
-                                            : ""
-                            }
-                        >
-                            <Tab value={i} label={label} disabled={disabled} />
-                        </Tooltip>
-                    );
-                })}
-            </Tabs>
-        </Box>
-    );
+          return (
+            <Tooltip
+              key={s}
+              title={
+                disabled
+                  ? "Locked by previous state guards"
+                  : dirty
+                    ? "Unsaved changes"
+                    : desync
+                      ? "Out-of-date due to upstream edits"
+                      : ""
+              }
+            >
+              <Tab
+                value={i}
+                label={label}
+                disabled={disabled}
+                component={NavLink}
+                to={id ? `/screenplays/${id}?state=${s}` : ""}
+                replace
+              />
+            </Tooltip>
+          );
+        })}
+      </Tabs>
+    </Box>
+  );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './app/App'
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+import "./index.css";
+import App from "./app/App";
 
-createRoot(document.getElementById('root')!).render(
+createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
-)
+);

--- a/src/pages/ScreenplayPage.tsx
+++ b/src/pages/ScreenplayPage.tsx
@@ -1,6 +1,7 @@
 // src/pages/ScreenplayPage.tsx
 import { useEffect, useMemo } from "react";
 import { Box, CircularProgress } from "@mui/material";
+import { useParams } from "react-router-dom";
 
 import { ScreenplayTabs } from "../components/ScreenplayTabs";
 import { RightSidebar } from "../components/RightSidebar/RightSidebar";
@@ -16,46 +17,60 @@ import S8FormattedDraftView from "../states/S8FormattedDraftView";
 import S9ReviewView from "../states/S9ReviewView";
 import S10ExportsView from "../states/S10ExportsView";
 
-
 import { useAppViewModel } from "../vm/useAppViewModel";
 import { useStateMachine } from "../vm/useStateMachine";
 import type { StateId } from "../models/enums";
 
 const SIDEBAR_WIDTH = 360; // ancho fijo y consistente
-const APPBAR_OFFSET = 88;  // pegajoso (ajusta si tu AppBar cambia)
+const APPBAR_OFFSET = 88; // pegajoso (ajusta si tu AppBar cambia)
 
 export default function ScreenplayPage() {
   const vm = useAppViewModel();
+  const { id } = useParams<{ id: string }>();
 
   const sm = useStateMachine({
     screenplay: vm.screenplay,
     currentState: vm.currentState,
-    setCurrentState: vm.setCurrentState
+    setCurrentState: vm.setCurrentState,
   });
 
   useEffect(() => {
-    vm.loadScreenplay(1);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    if (id) {
+      vm.loadScreenplay(Number(id));
+    }
+  }, [id, vm]);
 
   const Editor = useMemo(() => {
     switch (vm.currentState as StateId) {
-      case "S1_SYNOPSIS":       return <S1SynopsisView vm={vm} sm={sm} />;
-      case "S2_TREATMENT":      return <S2TreatmentView vm={vm} sm={sm} />;
-      case "S3_TURNING_POINTS": return <S3TurningPointsView vm={vm} sm={sm} />;
-      case "S4_CHARACTERS":     return <S4CharactersView vm={vm} sm={sm} />;
-      case "S5_SUBPLOTS":       return <S5SubplotsView vm={vm} sm={sm} />;
-      case "S6_KEY_SCENES":     return <S6KeyScenesView vm={vm} sm={sm} />;
-      case "S7_ALL_SCENES":     return <S7AllScenesView vm={vm} sm={sm} />;
-      case "S8_FORMATTED_DRAFT":return <S8FormattedDraftView vm={vm} sm={sm} />;
-      case "S9_REVIEW":         return <S9ReviewView vm={vm} sm={sm} />;
-      case "S10_EXPORTS":       return <S10ExportsView vm={vm} sm={sm} />;
-      default:                  return <S1SynopsisView vm={vm} sm={sm} />;
+      case "S1_SYNOPSIS":
+        return <S1SynopsisView vm={vm} sm={sm} />;
+      case "S2_TREATMENT":
+        return <S2TreatmentView vm={vm} sm={sm} />;
+      case "S3_TURNING_POINTS":
+        return <S3TurningPointsView vm={vm} sm={sm} />;
+      case "S4_CHARACTERS":
+        return <S4CharactersView vm={vm} sm={sm} />;
+      case "S5_SUBPLOTS":
+        return <S5SubplotsView vm={vm} sm={sm} />;
+      case "S6_KEY_SCENES":
+        return <S6KeyScenesView vm={vm} sm={sm} />;
+      case "S7_ALL_SCENES":
+        return <S7AllScenesView vm={vm} sm={sm} />;
+      case "S8_FORMATTED_DRAFT":
+        return <S8FormattedDraftView vm={vm} sm={sm} />;
+      case "S9_REVIEW":
+        return <S9ReviewView vm={vm} sm={sm} />;
+      case "S10_EXPORTS":
+        return <S10ExportsView vm={vm} sm={sm} />;
+      default:
+        return <S1SynopsisView vm={vm} sm={sm} />;
     }
   }, [vm.currentState, vm, sm]);
 
   // Evita warning de Tabs cuando aún no hay screenplay
-  const currentForTabs = (vm.screenplay ? vm.currentState : "S1_SYNOPSIS") as StateId;
+  const currentForTabs = (
+    vm.screenplay ? vm.currentState : "S1_SYNOPSIS"
+  ) as StateId;
 
   return (
     <Box>
@@ -73,7 +88,7 @@ export default function ScreenplayPage() {
           mt: 2,
           display: "grid",
           gridTemplateColumns: {
-            xs: "1fr",                                // móvil: sidebar abajo
+            xs: "1fr", // móvil: sidebar abajo
             md: `minmax(0, 1fr) ${SIDEBAR_WIDTH}px`, // desktop: 2 columnas
           },
           alignItems: "start",


### PR DESCRIPTION
## Summary
- wire up React Router and define /screenplays/:id route
- load screenplays by id via useParams
- expose screenplay tabs as NavLinks with query-state URLs

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: 155 problems)*
- `npm run check:types` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_689a2bcede088332adf2c75718878fac