### PR TITLE
feat: show global loading indicator

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -3,13 +3,16 @@ import { ThemeProvider, CssBaseline } from "@mui/material";
 import { theme } from "./theme";
 import { MainLayout } from "../layouts/MainLayout";
 import ScreenplayPage from "../pages/ScreenplayPage";
+import { useAppViewModel } from "../vm/useAppViewModel";
 
 export default function App() {
+  const vm = useAppViewModel();
+
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <MainLayout>
-        <ScreenplayPage />
+      <MainLayout loading={vm.loading}>
+        <ScreenplayPage vm={vm} />
       </MainLayout>
     </ThemeProvider>
   );

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,11 +1,23 @@
 // src/layouts/MainLayout.tsx
-import { AppBar, Toolbar, Typography, Box, Container, IconButton } from "@mui/material";
+import { AppBar, Toolbar, Typography, Box, Container, IconButton, LinearProgress } from "@mui/material";
 import MenuIcon from "@mui/icons-material/Menu";
-import { PropsWithChildren } from "react";
+import type { PropsWithChildren } from "react";
 
-export function MainLayout({ children }: PropsWithChildren) {
+export function MainLayout({ children, loading = false }: PropsWithChildren<{ loading?: boolean }>) {
   return (
     <Box sx={{ display: "grid", minHeight: "100dvh", gridTemplateRows: "64px 1fr" }}>
+      {loading && (
+        <LinearProgress
+          sx={{
+            position: "fixed",
+            top: 0,
+            left: 0,
+            right: 0,
+            zIndex: (theme) => theme.zIndex.appBar + 1,
+          }}
+        />
+      )}
+
       <AppBar position="sticky" color="inherit">
         <Toolbar>
           <IconButton edge="start" aria-label="menu" size="small">

--- a/src/pages/ScreenplayPage.tsx
+++ b/src/pages/ScreenplayPage.tsx
@@ -1,6 +1,6 @@
 // src/pages/ScreenplayPage.tsx
 import { useEffect, useMemo } from "react";
-import { Box, CircularProgress } from "@mui/material";
+import { Box } from "@mui/material";
 
 import { ScreenplayTabs } from "../components/ScreenplayTabs";
 import { RightSidebar } from "../components/RightSidebar/RightSidebar";
@@ -17,16 +17,14 @@ import S9ReviewView from "../states/S9ReviewView";
 import S10ExportsView from "../states/S10ExportsView";
 
 
-import { useAppViewModel } from "../vm/useAppViewModel";
+import type { AppViewModel } from "../vm/useAppViewModel";
 import { useStateMachine } from "../vm/useStateMachine";
 import type { StateId } from "../models/enums";
 
 const SIDEBAR_WIDTH = 360; // ancho fijo y consistente
 const APPBAR_OFFSET = 88;  // pegajoso (ajusta si tu AppBar cambia)
 
-export default function ScreenplayPage() {
-  const vm = useAppViewModel();
-
+export default function ScreenplayPage({ vm }: { vm: AppViewModel }) {
   const sm = useStateMachine({
     screenplay: vm.screenplay,
     currentState: vm.currentState,
@@ -82,13 +80,7 @@ export default function ScreenplayPage() {
       >
         {/* Columna izquierda (contenido principal) */}
         <Box sx={{ minWidth: 0 /* evita overflow por contenido amplio */ }}>
-          {vm.loading && !vm.screenplay ? (
-            <Box sx={{ display: "grid", placeItems: "center", minHeight: 280 }}>
-              <CircularProgress />
-            </Box>
-          ) : (
-            Editor
-          )}
+          {vm.loading && !vm.screenplay ? null : Editor}
         </Box>
 
         {/* Sidebar derecha fija */}

--- a/src/vm/useAppViewModel.ts
+++ b/src/vm/useAppViewModel.ts
@@ -82,3 +82,5 @@ export function useAppViewModel() {
     loadScreenplay, saveScreenplay
   };
 }
+
+export type AppViewModel = ReturnType<typeof useAppViewModel>;


### PR DESCRIPTION
## Summary
- bubble app loading state up to layout
- display a fixed LinearProgress bar when loading
- drop per-page CircularProgress loader

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: numerous lint errors in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_689a2bd28fe08332ad79950ad63d75a5