### PR TITLE
refactor: instantiate Fountain parser

### DIFF
--- a/src/utils/fountainParser.ts
+++ b/src/utils/fountainParser.ts
@@ -1,5 +1,7 @@
 // src/utils/fountainParser.ts
-import fountain from "fountain-js";
+import { Fountain } from "fountain-js";
+
+const fountain = new Fountain();
 
 export type ParaType =
   | "Scene Heading"


### PR DESCRIPTION
## Summary
- instantiate `Fountain` from `fountain-js` and reuse it when parsing scripts

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: 139 errors, 22 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689a3c48811c8332a7fcb5fa976aca84