### PR TITLE
fix: use ArrayBuffer for PDF Blob

### DIFF
--- a/src/utils/pdf.ts
+++ b/src/utils/pdf.ts
@@ -195,7 +195,7 @@ export async function exportPdf(sp: Screenplay, scenesIn: Scene[]) {
   }
 
   const bytes = await doc.save();
-  const blob = new Blob([bytes], { type: "application/pdf" });
+  const blob = new Blob([bytes.buffer as ArrayBuffer], { type: "application/pdf" });
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;


### PR DESCRIPTION
## Summary
- build PDF download using `bytes.buffer` cast to `ArrayBuffer` for valid BlobPart

## Testing
- `npm test` *(fails: No test files found, exiting with code 1)*
- `npm run lint` *(fails: 'fetch' is not defined, etc.)*
- `npm run check:types` *(fails: type errors in `src/states/S9ReviewView.tsx`)*

------
https://chatgpt.com/codex/tasks/task_e_689a3c8918588332b934e48b1fbccb01