### PR TITLE
refactor: update fountain type defs

### DIFF
--- a/src/types/fountain-js.d.ts
+++ b/src/types/fountain-js.d.ts
@@ -32,8 +32,7 @@ declare module "fountain-js" {
     title?: string;
   }
 
-  const fountain: {
-    parse: (src: string) => FountainParseResult;
-  };
-  export default fountain;
+  export class Fountain {
+    parse(src: string, getTokens?: boolean): FountainParseResult;
+  }
 }

--- a/src/utils/fountainParser.ts
+++ b/src/utils/fountainParser.ts
@@ -1,5 +1,7 @@
 // src/utils/fountainParser.ts
-import fountain from "fountain-js";
+import { Fountain } from "fountain-js";
+
+const fountain = new Fountain();
 
 export type ParaType =
   | "Scene Heading"


### PR DESCRIPTION
## Summary
- define and export Fountain class type
- instantiate Fountain in fountainParser utility

## Testing
- `npm run check:types` *(fails: Property 'item' missing, Cannot find namespace 'JSX', Type 'Uint8Array<ArrayBufferLike>' not assignable, etc.)*
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: URL is not defined, fetch is not defined, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689a3d17e21c8332b3ad3e2ef6f43ead