### PR TITLE
refactor: update mui grid usage

### DIFF
--- a/src/states/S3TurningPointsView.tsx
+++ b/src/states/S3TurningPointsView.tsx
@@ -10,12 +10,12 @@ import {
   MenuItem,
   Chip,
   Paper,
-  Grid,
   Dialog,
   DialogTitle,
   DialogContent,
   DialogActions,
 } from "@mui/material";
+import Grid from "@mui/material/Grid2";
 import { useNotify } from "./useNotify";
 import type { useAppViewModel } from "../vm/useAppViewModel";
 import type { useStateMachine } from "../vm/useStateMachine";
@@ -105,13 +105,13 @@ export default function S3TurningPointsView({ vm, sm }: { vm: VM; sm: SM }) {
 
         <Paper variant="outlined">
           <Grid container p={1} sx={{ bgcolor: "grey.50" }}>
-            <Grid item xs={12} md={3}>
+            <Grid xs={12} md={3}>
               <Typography variant="caption">Type</Typography>
             </Grid>
-            <Grid item xs={12} md={7}>
+            <Grid xs={12} md={7}>
               <Typography variant="caption">Summary</Typography>
             </Grid>
-            <Grid item xs={12} md={2}>
+            <Grid xs={12} md={2}>
               <Typography variant="caption">Order</Typography>
             </Grid>
           </Grid>
@@ -125,7 +125,7 @@ export default function S3TurningPointsView({ vm, sm }: { vm: VM; sm: SM }) {
               spacing={1}
               sx={{ borderTop: "1px solid", borderColor: "divider" }}
             >
-              <Grid item xs={12} md={3}>
+              <Grid xs={12} md={3}>
                 <Select
                   fullWidth
                   size="small"
@@ -141,7 +141,7 @@ export default function S3TurningPointsView({ vm, sm }: { vm: VM; sm: SM }) {
                   ))}
                 </Select>
               </Grid>
-              <Grid item xs={12} md={7}>
+              <Grid xs={12} md={7}>
                 <TextField
                   value={row.summary}
                   onChange={(e) => setRow(idx, { summary: e.target.value })}
@@ -152,7 +152,7 @@ export default function S3TurningPointsView({ vm, sm }: { vm: VM; sm: SM }) {
                   placeholder="What happens here and how it changes trajectory?"
                 />
               </Grid>
-              <Grid item xs={12} md={2}>
+              <Grid xs={12} md={2}>
                 <Select
                   fullWidth
                   size="small"

--- a/src/states/S4CharactersView.tsx
+++ b/src/states/S4CharactersView.tsx
@@ -5,7 +5,6 @@ import {
   Stack,
   Typography,
   Paper,
-  Grid,
   TextField,
   Select,
   MenuItem,
@@ -18,6 +17,7 @@ import {
   DialogContent,
   DialogActions,
 } from "@mui/material";
+import Grid from "@mui/material/Grid2";
 import { useNotify } from "./useNotify";
 import DeleteIcon from "@mui/icons-material/Delete";
 import AddIcon from "@mui/icons-material/Add";
@@ -267,7 +267,7 @@ export default function S4CharactersView({ vm, sm }: { vm: VM; sm: SM }) {
           <Divider />
           <Grid container spacing={2} p={2}>
             {(chars ?? []).map((c) => (
-              <Grid item xs={12} md={6} key={c.id}>
+              <Grid xs={12} md={6} key={c.id}>
                 <CharacterCard
                   c={c}
                   onChange={editCharacter}
@@ -308,7 +308,7 @@ export default function S4CharactersView({ vm, sm }: { vm: VM; sm: SM }) {
               />
             ))}
             {rels.length === 0 && (
-              <Grid item xs={12}>
+              <Grid xs={12}>
                 <Typography
                   variant="body2"
                   color="text.secondary"
@@ -413,7 +413,7 @@ export function CharacterCard({
       </Stack>
 
       <Grid container spacing={1} mt={0.5}>
-        <Grid item xs={12} md={6}>
+        <Grid xs={12} md={6}>
           <TextField
             label="Name"
             value={c.name}
@@ -422,7 +422,7 @@ export function CharacterCard({
             size="small"
           />
         </Grid>
-        <Grid item xs={12} md={6}>
+        <Grid xs={12} md={6}>
           <Select
             fullWidth
             size="small"
@@ -437,7 +437,7 @@ export function CharacterCard({
           </Select>
         </Grid>
 
-        <Grid item xs={12} md={4}>
+        <Grid xs={12} md={4}>
           <TextField
             label="Goal"
             value={c.goal ?? ""}
@@ -446,7 +446,7 @@ export function CharacterCard({
             size="small"
           />
         </Grid>
-        <Grid item xs={12} md={4}>
+        <Grid xs={12} md={4}>
           <TextField
             label="Need"
             value={c.need ?? ""}
@@ -455,7 +455,7 @@ export function CharacterCard({
             size="small"
           />
         </Grid>
-        <Grid item xs={12} md={4}>
+        <Grid xs={12} md={4}>
           <TextField
             label="Flaw"
             value={c.flaw ?? ""}
@@ -464,7 +464,7 @@ export function CharacterCard({
             size="small"
           />
         </Grid>
-        <Grid item xs={12}>
+        <Grid xs={12}>
           <TextField
             label="Arc summary"
             value={c.arc_summary ?? ""}
@@ -476,7 +476,7 @@ export function CharacterCard({
           />
         </Grid>
 
-        <Grid item xs={12}>
+        <Grid xs={12}>
           <Typography variant="caption" color="text.secondary">
             Archetypes per act
           </Typography>
@@ -486,7 +486,7 @@ export function CharacterCard({
                 c.archetype_timeline?.find((b) => b.phase === p)?.archetype ??
                 "ALLY";
               return (
-                <Grid item xs={12} md={4} key={p}>
+                <Grid xs={12} md={4} key={p}>
                   <Select
                     fullWidth
                     size="small"
@@ -508,7 +508,7 @@ export function CharacterCard({
           </Grid>
         </Grid>
 
-        <Grid item xs={12}>
+        <Grid xs={12}>
           <TextField
             label="Tags (comma-separated)"
             value={(c.tags ?? []).join(", ")}
@@ -544,7 +544,7 @@ function RelationshipRow({
 
   return (
     <Grid container spacing={1} alignItems="center">
-      <Grid item xs={12} md={3}>
+      <Grid xs={12} md={3}>
         <Select
           fullWidth
           size="small"
@@ -558,7 +558,7 @@ function RelationshipRow({
           ))}
         </Select>
       </Grid>
-      <Grid item xs={12} md={4}>
+      <Grid xs={12} md={4}>
         <Select
           fullWidth
           size="small"
@@ -572,7 +572,7 @@ function RelationshipRow({
           ))}
         </Select>
       </Grid>
-      <Grid item xs={12} md={3}>
+      <Grid xs={12} md={3}>
         <Select
           fullWidth
           size="small"
@@ -586,7 +586,7 @@ function RelationshipRow({
           ))}
         </Select>
       </Grid>
-      <Grid item xs={12} md={1.5}>
+      <Grid xs={12} md={1.5}>
         <TextField
           label="Strength"
           size="small"
@@ -596,7 +596,7 @@ function RelationshipRow({
           onChange={(e) => set({ strength: Number(e.target.value) })}
         />
       </Grid>
-      <Grid item xs={12} md={1.5}>
+      <Grid xs={12} md={1.5}>
         <Stack direction="row" alignItems="center" spacing={1}>
           <TextField
             label="Trust"

--- a/src/states/S5SubplotsView.tsx
+++ b/src/states/S5SubplotsView.tsx
@@ -5,7 +5,6 @@ import {
   Stack,
   Typography,
   Paper,
-  Grid,
   TextField,
   Select,
   MenuItem,
@@ -20,6 +19,7 @@ import {
   Checkbox,
   ListItemText,
 } from "@mui/material";
+import Grid from "@mui/material/Grid2";
 import { useNotify } from "./useNotify";
 import DeleteIcon from "@mui/icons-material/Delete";
 import AddIcon from "@mui/icons-material/Add";
@@ -188,7 +188,7 @@ export default function S5SubplotsView({ vm, sm }: { vm: VM; sm: SM }) {
           <Divider />
           <Grid container spacing={2} p={2}>
             {subplots.map((spo) => (
-              <Grid item xs={12} key={spo.id}>
+              <Grid xs={12} key={spo.id}>
                 <SubplotCard
                   s={spo}
                   onChange={onChange}
@@ -199,7 +199,7 @@ export default function S5SubplotsView({ vm, sm }: { vm: VM; sm: SM }) {
               </Grid>
             ))}
             {subplots.length === 0 && (
-              <Grid item xs={12}>
+              <Grid xs={12}>
                 <Typography variant="body2" color="text.secondary">
                   No subplots yet.
                 </Typography>
@@ -314,7 +314,7 @@ export function SubplotCard({
       </Stack>
 
       <Grid container spacing={1} mt={0.5}>
-        <Grid item xs={12} md={6}>
+        <Grid xs={12} md={6}>
           <TextField
             label="Title"
             value={s.title}
@@ -323,7 +323,7 @@ export function SubplotCard({
             size="small"
           />
         </Grid>
-        <Grid item xs={12} md={3}>
+        <Grid xs={12} md={3}>
           <Select
             fullWidth
             size="small"
@@ -337,11 +337,11 @@ export function SubplotCard({
             ))}
           </Select>
         </Grid>
-        <Grid item xs={12} md={3}>
+        <Grid xs={12} md={3}>
           <ActsToggles value={s.dominantActs} onToggle={toggleAct} />
         </Grid>
 
-        <Grid item xs={12}>
+        <Grid xs={12}>
           <TextField
             label="Purpose"
             value={s.purpose}
@@ -351,14 +351,14 @@ export function SubplotCard({
           />
         </Grid>
 
-        <Grid item xs={12} md={6}>
+        <Grid xs={12} md={6}>
           <MultiSelectCharacters
             value={s.charactersInvolved}
             onChange={(ids) => set({ charactersInvolved: ids })}
             characters={characters}
           />
         </Grid>
-        <Grid item xs={12} md={6}>
+        <Grid xs={12} md={6}>
           <MultiSelectTPs
             value={s.linkedTurningPoints ?? []}
             onChange={(ids) => set({ linkedTurningPoints: ids })}
@@ -366,7 +366,7 @@ export function SubplotCard({
           />
         </Grid>
 
-        <Grid item xs={12}>
+        <Grid xs={12}>
           <Stack
             direction="row"
             alignItems="center"
@@ -395,7 +395,7 @@ export function SubplotCard({
                 key={idx}
                 sx={{ mb: 1 }}
               >
-                <Grid item xs={12} md={1.2}>
+                <Grid xs={12} md={1.2}>
                   <TextField
                     label="Order"
                     size="small"
@@ -406,7 +406,7 @@ export function SubplotCard({
                     }
                   />
                 </Grid>
-                <Grid item xs={12} md={7}>
+                <Grid xs={12} md={7}>
                   <TextField
                     label="Summary"
                     size="small"
@@ -415,7 +415,7 @@ export function SubplotCard({
                     fullWidth
                   />
                 </Grid>
-                <Grid item xs={12} md={3.3}>
+                <Grid xs={12} md={3.3}>
                   <TextField
                     label="Out change"
                     size="small"
@@ -426,7 +426,7 @@ export function SubplotCard({
                     fullWidth
                   />
                 </Grid>
-                <Grid item xs={12} md={0.5}>
+                <Grid xs={12} md={0.5}>
                   <IconButton size="small" onClick={() => delBeat(idx)}>
                     <DeleteIcon fontSize="small" />
                   </IconButton>

--- a/src/states/S6KeyScenesView.tsx
+++ b/src/states/S6KeyScenesView.tsx
@@ -5,7 +5,6 @@ import {
   Stack,
   Typography,
   Paper,
-  Grid,
   TextField,
   Select,
   MenuItem,
@@ -18,6 +17,7 @@ import {
   DialogContent,
   DialogActions,
 } from "@mui/material";
+import Grid from "@mui/material/Grid2";
 import { useNotify } from "./useNotify";
 import DeleteIcon from "@mui/icons-material/Delete";
 import AddIcon from "@mui/icons-material/Add";
@@ -182,16 +182,24 @@ export default function S6KeyScenesView({ vm, sm }: { vm: VM; sm: SM }) {
         </Typography>
 
         <Stack direction="row" spacing={1} alignItems="center">
-          <Button variant="outlined" onClick={proposeAll} disabled={!tps.length}>Propose All from Turning Points</Button>
+          <Button
+            variant="outlined"
+            onClick={proposeAll}
+            disabled={!tps.length}
+          >
+            Propose All from Turning Points
+          </Button>
           <WorkflowActions
             onSave={saveAll}
             onApprove={approve}
             saveDisabled={!vm.dirtyByState["S6_KEY_SCENES"]}
           >
             <Chip size="small" label={`Key scenes: ${stats.count}`} />
-            <Chip size="small" label={`TP covered: ${stats.covered}/${stats.need || "-"}`} />
+            <Chip
+              size="small"
+              label={`TP covered: ${stats.covered}/${stats.need || "-"}`}
+            />
           </WorkflowActions>
-
         </Stack>
 
         {/* Lista por TP */}
@@ -304,7 +312,7 @@ function SceneRow({
   return (
     <Paper variant="outlined" sx={{ p: 1.5 }}>
       <Grid container spacing={1} alignItems="center">
-        <Grid item xs={12} md={2.2}>
+        <Grid xs={12} md={2.2}>
           <TextField
             size="small"
             label="Title"
@@ -312,7 +320,7 @@ function SceneRow({
             onChange={(e) => set({ title: e.target.value })}
           />
         </Grid>
-        <Grid item xs={12} md={1.8}>
+        <Grid xs={12} md={1.8}>
           <Select
             size="small"
             fullWidth
@@ -326,7 +334,7 @@ function SceneRow({
             ))}
           </Select>
         </Grid>
-        <Grid item xs={12} md={3}>
+        <Grid xs={12} md={3}>
           <TextField
             size="small"
             label="Location"
@@ -335,7 +343,7 @@ function SceneRow({
             fullWidth
           />
         </Grid>
-        <Grid item xs={12} md={1.5}>
+        <Grid xs={12} md={1.5}>
           <Select
             size="small"
             fullWidth
@@ -349,7 +357,7 @@ function SceneRow({
             ))}
           </Select>
         </Grid>
-        <Grid item xs={12} md={3.5}>
+        <Grid xs={12} md={3.5}>
           <TextField
             size="small"
             label="Synopsis"
@@ -358,7 +366,7 @@ function SceneRow({
             fullWidth
           />
         </Grid>
-        <Grid item xs={12} md={0.6}>
+        <Grid xs={12} md={0.6}>
           <IconButton
             size="small"
             onClick={() => onRemove(scene.id)}
@@ -369,7 +377,7 @@ function SceneRow({
         </Grid>
       </Grid>
       <Grid container spacing={1} mt={0.5}>
-        <Grid item xs={12} md={4}>
+        <Grid xs={12} md={4}>
           <TextField
             size="small"
             label="Goal"
@@ -378,7 +386,7 @@ function SceneRow({
             fullWidth
           />
         </Grid>
-        <Grid item xs={12} md={4}>
+        <Grid xs={12} md={4}>
           <TextField
             size="small"
             label="Conflict"
@@ -387,7 +395,7 @@ function SceneRow({
             fullWidth
           />
         </Grid>
-        <Grid item xs={12} md={4}>
+        <Grid xs={12} md={4}>
           <TextField
             size="small"
             label="Outcome"

--- a/src/states/S7AllScenesView.tsx
+++ b/src/states/S7AllScenesView.tsx
@@ -5,7 +5,6 @@ import {
   Stack,
   Typography,
   Paper,
-  Grid,
   TextField,
   Select,
   MenuItem,
@@ -14,6 +13,7 @@ import {
   IconButton,
   Divider,
 } from "@mui/material";
+import Grid from "@mui/material/Grid2";
 import { useNotify } from "./useNotify";
 import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
 import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
@@ -168,7 +168,13 @@ export default function S7AllScenesView({ vm, sm }: { vm: VM; sm: SM }) {
         </Typography>
 
         <Stack direction="row" spacing={1} alignItems="center">
-          <Button variant="outlined" onClick={proposeNonKey} disabled={proposing}>Propose non-key scenes</Button>
+          <Button
+            variant="outlined"
+            onClick={proposeNonKey}
+            disabled={proposing}
+          >
+            Propose non-key scenes
+          </Button>
           <WorkflowActions
             onSave={saveAll}
             onApprove={approve}
@@ -178,7 +184,6 @@ export default function S7AllScenesView({ vm, sm }: { vm: VM; sm: SM }) {
             <Chip size="small" label={`Key: ${stats.key}`} />
             <Chip size="small" label={`Non-key: ${stats.nonKey}`} />
           </WorkflowActions>
-
         </Stack>
 
         <Paper variant="outlined">
@@ -243,10 +248,10 @@ function SceneRow({
   return (
     <Paper variant="outlined" sx={{ p: 1.25 }}>
       <Grid container spacing={1} alignItems="center">
-        <Grid item xs={12} md={0.8}>
+        <Grid xs={12} md={0.8}>
           <Chip size="small" label={scene.order} />
         </Grid>
-        <Grid item xs={12} md={1.4}>
+        <Grid xs={12} md={1.4}>
           {scene.is_key ? (
             <Chip
               size="small"
@@ -257,7 +262,7 @@ function SceneRow({
             <Chip size="small" variant="outlined" label="non-key" />
           )}
         </Grid>
-        <Grid item xs={12} md={1.8}>
+        <Grid xs={12} md={1.8}>
           <Select
             size="small"
             fullWidth
@@ -271,7 +276,7 @@ function SceneRow({
             ))}
           </Select>
         </Grid>
-        <Grid item xs={12} md={2.5}>
+        <Grid xs={12} md={2.5}>
           <TextField
             size="small"
             label="Location"
@@ -280,7 +285,7 @@ function SceneRow({
             fullWidth
           />
         </Grid>
-        <Grid item xs={12} md={1.4}>
+        <Grid xs={12} md={1.4}>
           <Select
             size="small"
             fullWidth
@@ -294,7 +299,7 @@ function SceneRow({
             ))}
           </Select>
         </Grid>
-        <Grid item xs={12} md={3.5}>
+        <Grid xs={12} md={3.5}>
           <TextField
             size="small"
             label="Synopsis"
@@ -303,7 +308,7 @@ function SceneRow({
             fullWidth
           />
         </Grid>
-        <Grid item xs={12} md={0.6}>
+        <Grid xs={12} md={0.6}>
           <Stack direction="row" spacing={0.5}>
             <IconButton
               size="small"
@@ -321,7 +326,7 @@ function SceneRow({
             </IconButton>
           </Stack>
         </Grid>
-        <Grid item xs={12} md={0.6}>
+        <Grid xs={12} md={0.6}>
           <Stack direction="row" spacing={0.5}>
             <IconButton size="small" onClick={onAddBelow} title="Add below">
               <AddIcon fontSize="small" />

--- a/src/states/S8FormattedDraftView.tsx
+++ b/src/states/S8FormattedDraftView.tsx
@@ -5,13 +5,13 @@ import {
   Stack,
   Typography,
   Paper,
-  Grid,
   TextField,
   Button,
   Chip,
   IconButton,
   Divider,
 } from "@mui/material";
+import Grid from "@mui/material/Grid2";
 import { useNotify } from "./useNotify";
 import AutoFixHighIcon from "@mui/icons-material/AutoFixHigh";
 import DownloadIcon from "@mui/icons-material/Download";
@@ -102,14 +102,26 @@ export default function S8FormattedDraftView({ vm, sm }: { vm: VM; sm: SM }) {
         </Typography>
 
         <Stack direction="row" spacing={1} alignItems="center">
-          <Button variant="outlined" startIcon={<DownloadIcon />} onClick={compile}>Compile & Download (.fountain)</Button>
+          <Button
+            variant="outlined"
+            startIcon={<DownloadIcon />}
+            onClick={compile}
+          >
+            Compile & Download (.fountain)
+          </Button>
           <WorkflowActions
             onSave={saveAll}
             onApprove={approve}
             saveDisabled={!vm.dirtyByState["S8_FORMATTED_DRAFT"]}
           >
-            <Chip size="small" label={`Scenes drafted: ${drafted}/${scenes.length}`} />
-            <Chip size="small" label={`Key drafted: ${coveredKeys}/${keyCount}`} />
+            <Chip
+              size="small"
+              label={`Scenes drafted: ${drafted}/${scenes.length}`}
+            />
+            <Chip
+              size="small"
+              label={`Key drafted: ${coveredKeys}/${keyCount}`}
+            />
           </WorkflowActions>
         </Stack>
 
@@ -202,7 +214,7 @@ export function SceneEditor({
         </Stack>
       </Stack>
       <Grid container spacing={1}>
-        <Grid item xs={12}>
+        <Grid xs={12}>
           <TextField
             label="Fountain (formatted text for this scene)"
             value={sc.formatted_text ?? ""}

--- a/src/states/S9ReviewView.tsx
+++ b/src/states/S9ReviewView.tsx
@@ -13,11 +13,11 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
-  Grid,
   TextField,
   Alert,
   AlertTitle,
 } from "@mui/material";
+import Grid from "@mui/material/Grid2";
 import { useNotify } from "./useNotify";
 import EditIcon from "@mui/icons-material/Edit";
 import SaveIcon from "@mui/icons-material/Save";
@@ -461,7 +461,7 @@ function SceneBlock({
       ) : (
         <Box sx={{ mt: 1 }}>
           <Grid container spacing={1}>
-            <Grid item xs={12}>
+            <Grid xs={12}>
               <TextField
                 value={draftBuffer}
                 onChange={(e) => onChangeDraft(e.target.value)}
@@ -471,7 +471,7 @@ function SceneBlock({
                 placeholder={text}
               />
             </Grid>
-            <Grid item xs={12}>
+            <Grid xs={12}>
               <Stack direction="row" spacing={1}>
                 <Button
                   variant="contained"


### PR DESCRIPTION
## Summary
- refactor state view grid imports to `@mui/material/Grid2`
- drop deprecated `item` prop in MUI Grid cells

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: errors: no-unused-vars, no-undef, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689a3c869d8083329503fa2bef3c3cc3